### PR TITLE
fix: prompt for MFA code inline when stdin is a terminal

### DIFF
--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -60,7 +60,7 @@ def start_xvfb(display=":99"):
 
 
 # ---------------------------------------------------------------------------
-# MFA handoff (file-based, works without interactive stdin)
+# MFA handoff
 # ---------------------------------------------------------------------------
 
 
@@ -79,10 +79,19 @@ def wait_for_mfa() -> str:
     except ImportError:
         pass
 
-    # Manual file-based fallback
+    # Interactive fallback — prompt inline when stdin is a terminal
+    print()
+    print("MFA REQUIRED — check your email for the 6-digit code.")
+    if sys.stdin.isatty():
+        while True:
+            code = input("  Enter code: ").strip()
+            if code:
+                return code
+            print("  No code entered — please try again.")
+
+    # Non-interactive fallback (cron / piped stdin) — poll a file
     MFA_FILE.unlink(missing_ok=True)
     print("=" * 50)
-    print("MFA REQUIRED — check your email")
     print(f"Run: echo YOUR_CODE > {MFA_FILE}")
     print("Waiting up to 5 minutes...")
     print("=" * 50)


### PR DESCRIPTION
## Summary

- When Garmin triggers MFA and Gmail automation isn't available, the tool now prompts for the code directly in the current terminal instead of requiring a second terminal window
- Non-interactive environments (cron, piped stdin) automatically fall back to the existing `.mfa_code` file-based path — no behavior change for unattended operation

## Before / After

**Before:** `Run: echo YOUR_CODE > .mfa_code` — user had to open a second terminal

**After:** `Enter code: ______` — inline prompt in the same session

## Test plan

- [ ] Interactive pull triggering MFA → code prompted inline, pull completes
- [ ] Cron / non-TTY run → file-based `.mfa_code` path still used

🤖 Generated with [Claude Code](https://claude.com/claude-code)