### PR TITLE
feat: Phase 2 TUI — full screen hierarchy with live pull progress

### DIFF
--- a/garmin_extract/app.py
+++ b/garmin_extract/app.py
@@ -1,64 +1,24 @@
-"""
-Textual TUI application for garmin-extract.
-
-Phase 1: placeholder shell — confirms the package, entry point, and
-routing all work before the full screen hierarchy is built in Phase 2.
-"""
+"""Textual TUI application for garmin-extract."""
 
 from __future__ import annotations
 
-from textual.app import App, ComposeResult
-from textual.binding import Binding
-from textual.widgets import Footer, Header, Static
+from textual.app import App
 
 from garmin_extract import __version__
 
-_PLACEHOLDER = """\
- ┌─────────────────────────────────────────┐
- │                                         │
- │   garmin-extract  TUI                   │
- │   Phase 2 — coming soon                 │
- │                                         │
- │   The full interactive interface is     │
- │   being built. In the meantime, use:    │
- │                                         │
- │     python -m garmin_extract --no-tui   │
- │                                         │
- └─────────────────────────────────────────┘
-"""
-
 
 class GarminExtractApp(App[None]):
-    """garmin-extract TUI (Phase 1 placeholder)."""
+    """garmin-extract TUI — boots to the main menu."""
 
     TITLE = f"garmin-extract  v{__version__}"
     SUB_TITLE = "Automated Garmin Connect data pipeline"
-
-    BINDINGS = [
-        Binding("q", "quit", "Quit", show=True),
-    ]
-
-    CSS = """
-    Screen {
-        align: center middle;
-        background: $surface;
-    }
-
-    #placeholder {
-        width: auto;
-        height: auto;
-        padding: 1 2;
-        color: $text-muted;
-        text-align: center;
-    }
-    """
 
     def __init__(self, dry_run: bool = False, verbose: int = 0) -> None:
         super().__init__()
         self.dry_run = dry_run
         self.verbose = verbose
 
-    def compose(self) -> ComposeResult:
-        yield Header()
-        yield Static(_PLACEHOLDER, id="placeholder")
-        yield Footer()
+    def on_mount(self) -> None:
+        from garmin_extract.screens.main_menu import MainMenuScreen
+
+        self.push_screen(MainMenuScreen())

--- a/garmin_extract/screens/data_pull.py
+++ b/garmin_extract/screens/data_pull.py
@@ -1,0 +1,339 @@
+"""Data pull screen — submenu for all pull and report options."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Input, Static
+
+_SECTION = "  [bold dim]{title}[/]\n  " + "─" * 51
+
+
+def _date_range_label(days: int) -> str:
+    today = date.today()
+    start = today - timedelta(days=days)
+    end = today - timedelta(days=1)
+    return f"{start.isoformat()}  →  {end.isoformat()}"
+
+
+def _yesterday() -> str:
+    return (date.today() - timedelta(days=1)).isoformat()
+
+
+class DataPullScreen(Screen[None]):
+    """Submenu for pulling data and rebuilding reports."""
+
+    BINDINGS = [
+        Binding("1", "pull_yesterday", show=False),
+        Binding("2", "pull_7", show=False),
+        Binding("3", "pull_30", show=False),
+        Binding("4", "pull_custom", show=False),
+        Binding("5", "pull_history", show=False),
+        Binding("6", "import_zip", show=False),
+        Binding("7", "rebuild_csvs", show=False),
+        Binding("b", "back", "Back", show=True),
+        Binding("q", "quit", "Quit", show=True),
+    ]
+
+    CSS = """
+    DataPullScreen {
+        align: center middle;
+    }
+
+    #pull-menu {
+        width: 57;
+        height: auto;
+        color: $text;
+        margin-bottom: 1;
+    }
+
+    #pull-hint {
+        width: 57;
+        text-align: center;
+        color: $text-muted;
+    }
+
+    #custom-input-container {
+        width: 57;
+        height: auto;
+        display: none;
+        padding: 1 2;
+        border: round $warning;
+    }
+
+    #custom-input-container.visible {
+        display: block;
+    }
+    """
+
+    def _build_menu(self) -> str:
+        yest = _yesterday()
+        r7 = _date_range_label(7)
+        r30 = _date_range_label(30)
+        return (
+            f"\n"
+            f"  [bold dim]RECENT[/]\n  {'─' * 51}\n"
+            f"  [bold cyan][1][/]  Yesterday              [dim]{yest}[/]\n"
+            f"  [bold cyan][2][/]  Last 7 days            [dim]{r7}[/]\n"
+            f"  [bold cyan][3][/]  Last 30 days           [dim]{r30}[/]\n"
+            f"\n"
+            f"  [bold dim]CUSTOM[/]\n  {'─' * 51}\n"
+            f"  [bold cyan][4][/]  Specific date or range\n"
+            f"  [bold cyan][5][/]  Full history  [dim](from a date you choose)[/]\n"
+            f"\n"
+            f"  [bold dim]IMPORT[/]\n  {'─' * 51}\n"
+            f"  [bold cyan][6][/]  Import from Garmin bulk export  [dim](.zip)[/]\n"
+            f"\n"
+            f"  [bold dim]REPORTS[/]\n  {'─' * 51}\n"
+            f"  [bold cyan][7][/]  Rebuild CSV reports  [dim](from existing data)[/]\n"
+        )
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static(self._build_menu(), id="pull-menu")
+        yield Static(
+            "Press a number to select  ·  b  back  ·  q  quit",
+            id="pull-hint",
+        )
+        yield Footer()
+
+    def _push_progress(
+        self,
+        start_date: str,
+        days: int,
+        label: str,
+        no_skip: bool = False,
+        rebuild_only: bool = False,
+    ) -> None:
+        from garmin_extract.screens.pull_progress import PullProgressScreen
+
+        self.app.push_screen(
+            PullProgressScreen(
+                start_date=start_date,
+                days=days,
+                label=label,
+                no_skip=no_skip,
+                rebuild_only=rebuild_only,
+            )
+        )
+
+    def action_pull_yesterday(self) -> None:
+        yest = _yesterday()
+        self._push_progress(yest, 1, f"Yesterday  ({yest})")
+
+    def action_pull_7(self) -> None:
+        start = (date.today() - timedelta(days=7)).isoformat()
+        self._push_progress(start, 7, f"Last 7 days  ({_date_range_label(7)})")
+
+    def action_pull_30(self) -> None:
+        start = (date.today() - timedelta(days=30)).isoformat()
+        self._push_progress(start, 30, f"Last 30 days  ({_date_range_label(30)})")
+
+    def action_pull_custom(self) -> None:
+        self.app.push_screen(CustomDateScreen())
+
+    def action_pull_history(self) -> None:
+        self.app.push_screen(FullHistoryScreen())
+
+    def action_import_zip(self) -> None:
+        self.app.push_screen(ImportZipScreen())
+
+    def action_rebuild_csvs(self) -> None:
+        self._push_progress("", 0, "Rebuilding CSV reports", rebuild_only=True)
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_quit(self) -> None:
+        self.app.exit()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Input screens for custom / history / import flows
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _parse_date(s: str) -> str | None:
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y", "%m-%d-%Y", "%m-%d-%y"):
+        try:
+            return datetime.strptime(s.strip(), fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return None
+
+
+class _InputScreen(Screen[None]):
+    """Base class for single-step input screens."""
+
+    BINDINGS = [
+        Binding("escape", "back", "Back", show=True),
+        Binding("q", "quit", "Quit", show=True),
+    ]
+
+    CSS = """
+    _InputScreen {
+        align: center middle;
+    }
+
+    #input-box {
+        width: 58;
+        height: auto;
+        border: round $primary;
+        padding: 1 2;
+    }
+
+    #input-title {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #input-hint {
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    #input-error {
+        color: $error;
+        height: 1;
+    }
+    """
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_quit(self) -> None:
+        self.app.exit()
+
+
+class CustomDateScreen(_InputScreen):
+    """Prompt for a start date and optional day count."""
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Static(id="input-box"):
+            yield Static("Custom Date Pull", id="input-title")
+            yield Static(
+                "Formats: YYYY-MM-DD  ·  MM/DD/YYYY  ·  MM/DD/YY",
+                id="input-hint",
+            )
+            yield Input(placeholder="Start date", id="start-date")
+            yield Input(placeholder="Number of days  (default: 1)", id="num-days")
+            yield Static("", id="input-error")
+        yield Footer()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "start-date":
+            self.query_one("#num-days", Input).focus()
+            return
+
+        start_raw = self.query_one("#start-date", Input).value.strip()
+        days_raw = self.query_one("#num-days", Input).value.strip()
+        error = self.query_one("#input-error", Static)
+
+        start = _parse_date(start_raw)
+        if not start:
+            error.update(f"Cannot parse '{start_raw}' — try 2025-04-07")
+            self.query_one("#start-date", Input).focus()
+            return
+
+        days = int(days_raw) if days_raw.isdigit() and int(days_raw) > 0 else 1
+
+        self._push_pull(start, days)
+
+    def _push_pull(self, start: str, days: int) -> None:
+        from garmin_extract.screens.pull_progress import PullProgressScreen
+
+        self.app.pop_screen()
+        self.app.push_screen(
+            PullProgressScreen(start_date=start, days=days, label=f"Custom  ({start}, {days}d)")
+        )
+
+
+class FullHistoryScreen(_InputScreen):
+    """Prompt for a start date for a full history pull."""
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Static(id="input-box"):
+            yield Static("Full History Pull", id="input-title")
+            yield Static(
+                "Pulls every day from your chosen start date through yesterday.\n"
+                "Formats: YYYY-MM-DD  ·  MM/DD/YYYY  ·  MM/DD/YY",
+                id="input-hint",
+            )
+            yield Input(placeholder="Pull data starting from", id="start-date")
+            yield Static("", id="input-error")
+        yield Footer()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        raw = self.query_one("#start-date", Input).value.strip()
+        error = self.query_one("#input-error", Static)
+
+        start = _parse_date(raw)
+        if not start:
+            error.update(f"Cannot parse '{raw}' — try 2023-01-01")
+            return
+
+        start_dt = datetime.strptime(start, "%Y-%m-%d").date()
+        yesterday = date.today() - timedelta(days=1)
+        days = (yesterday - start_dt).days + 1
+
+        if days <= 0:
+            error.update("Start date must be before today.")
+            return
+
+        from garmin_extract.screens.pull_progress import PullProgressScreen
+
+        self.app.pop_screen()
+        self.app.push_screen(
+            PullProgressScreen(
+                start_date=start,
+                days=days,
+                label=f"Full history  ({start} → {yesterday.isoformat()})",
+            )
+        )
+
+
+class ImportZipScreen(_InputScreen):
+    """Prompt for the path to a Garmin bulk export .zip."""
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Static(id="input-box"):
+            yield Static("Import from Garmin Bulk Export", id="input-title")
+            yield Static(
+                "Request your export at:\n"
+                "Garmin Connect → Profile → Account → Your Garmin Data\n"
+                "The .zip file arrives within 24–48 hours.",
+                id="input-hint",
+            )
+            yield Input(placeholder="Path to export .zip", id="zip-path")
+            yield Static("", id="input-error")
+        yield Footer()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        raw = self.query_one("#zip-path", Input).value.strip().strip("'\"")
+        error = self.query_one("#input-error", Static)
+
+        if not raw:
+            return
+
+        if not Path(raw).exists():
+            error.update(f"File not found: {raw}")
+            return
+
+        from garmin_extract.screens.pull_progress import PullProgressScreen
+
+        self.app.pop_screen()
+        self.app.push_screen(
+            PullProgressScreen(
+                start_date="",
+                days=0,
+                label="Garmin bulk export import",
+                zip_path=raw,
+            )
+        )

--- a/garmin_extract/screens/main_menu.py
+++ b/garmin_extract/screens/main_menu.py
@@ -1,0 +1,93 @@
+"""Main menu screen — the landing screen for the TUI."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Static
+
+from garmin_extract import __version__
+
+_MENU = f"""\
+  garmin-extract  v{__version__}
+  Automated Garmin Connect data pipeline\
+"""
+
+_OPTIONS = """\
+
+  ┌─────────────────────────────────────────────────────┐
+  │                                                     │
+  │   [1]  Initial Setup                                │
+  │        Configure credentials and prerequisites      │
+  │                                                     │
+  │   [2]  Pull Data                                    │
+  │        Download your Garmin health metrics          │
+  │                                                     │
+  │   [3]  Automation                                   │
+  │        Gmail MFA, scheduled pulls, Drive / Sheets   │
+  │                                                     │
+  └─────────────────────────────────────────────────────┘\
+"""
+
+
+class MainMenuScreen(Screen[None]):
+    """Landing screen — routes to the three main sections."""
+
+    BINDINGS = [
+        Binding("1", "go_setup", "Initial Setup", show=False),
+        Binding("2", "go_pull", "Pull Data", show=False),
+        Binding("3", "go_automation", "Automation", show=False),
+        Binding("q", "quit", "Quit", show=True),
+    ]
+
+    CSS = """
+    MainMenuScreen {
+        align: center middle;
+    }
+
+    #menu-header {
+        width: 57;
+        text-align: center;
+        color: $accent;
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #menu-options {
+        width: 57;
+        color: $text;
+    }
+
+    #menu-hint {
+        width: 57;
+        text-align: center;
+        color: $text-muted;
+        margin-top: 1;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static(_MENU, id="menu-header")
+        yield Static(_OPTIONS, id="menu-options")
+        yield Static("Press  1  2  3  to select  ·  q  to quit", id="menu-hint")
+        yield Footer()
+
+    def action_go_setup(self) -> None:
+        from garmin_extract.screens.stub import StubScreen
+
+        self.app.push_screen(StubScreen("Initial Setup", "Phase 3"))
+
+    def action_go_pull(self) -> None:
+        from garmin_extract.screens.data_pull import DataPullScreen
+
+        self.app.push_screen(DataPullScreen())
+
+    def action_go_automation(self) -> None:
+        from garmin_extract.screens.stub import StubScreen
+
+        self.app.push_screen(StubScreen("Automation", "Phase 4"))
+
+    def action_quit(self) -> None:
+        self.app.exit()

--- a/garmin_extract/screens/pull_progress.py
+++ b/garmin_extract/screens/pull_progress.py
@@ -1,0 +1,409 @@
+"""Pull progress screen — live metric-by-metric pull with split log panel."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Footer, Header, Input, ProgressBar, RichLog, Static
+
+ROOT = Path(__file__).parent.parent.parent
+MFA_FILE = ROOT / ".mfa_code"
+
+_METRICS: list[str] = [
+    "stats",
+    "user_summary_chart",
+    "heart_rates",
+    "resting_hr",
+    "hrv",
+    "stress",
+    "body_battery",
+    "body_battery_events",
+    "sleep",
+    "steps",
+    "floors",
+    "spo2",
+    "respiration",
+    "intensity_minutes",
+    "all_day_events",
+    "activities",
+    "weigh_ins",
+    "body_composition",
+    "blood_pressure",
+    "max_metrics",
+    "training_readiness",
+    "training_status",
+    "fitness_age",
+    "hydration",
+    "lifestyle",
+]
+
+_LABEL: dict[str, str] = {
+    "stats": "Daily Summary",
+    "user_summary_chart": "Summary Chart",
+    "heart_rates": "Heart Rate",
+    "resting_hr": "Resting HR",
+    "hrv": "HRV",
+    "stress": "Stress",
+    "body_battery": "Body Battery",
+    "body_battery_events": "BB Events",
+    "sleep": "Sleep",
+    "steps": "Steps",
+    "floors": "Floors",
+    "spo2": "SpO\u2082",
+    "respiration": "Respiration",
+    "intensity_minutes": "Intensity Min",
+    "all_day_events": "All-Day Events",
+    "activities": "Activities",
+    "weigh_ins": "Weigh-Ins",
+    "body_composition": "Body Comp",
+    "blood_pressure": "Blood Pressure",
+    "max_metrics": "Max Metrics",
+    "training_readiness": "Train Ready",
+    "training_status": "Train Status",
+    "fitness_age": "Fitness Age",
+    "hydration": "Hydration",
+    "lifestyle": "Lifestyle",
+}
+
+
+class _MfaModal(ModalScreen[None]):
+    """Pop-up dialog to capture an MFA code and write it to .mfa_code."""
+
+    BINDINGS = [Binding("escape", "dismiss", "Cancel", show=True)]
+
+    CSS = """
+    _MfaModal {
+        align: center middle;
+    }
+
+    #mfa-box {
+        width: 52;
+        height: auto;
+        border: round $warning;
+        padding: 1 2;
+    }
+
+    #mfa-title {
+        text-style: bold;
+        color: $warning;
+        margin-bottom: 1;
+    }
+
+    #mfa-hint {
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    #mfa-error {
+        color: $error;
+        height: 1;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Static(id="mfa-box"):
+            yield Static("MFA Code Required", id="mfa-title")
+            yield Static(
+                "Check your email for a 6-digit code and enter it below.",
+                id="mfa-hint",
+            )
+            yield Input(placeholder="000000", id="mfa-input", max_length=6)
+            yield Static("", id="mfa-error")
+
+    def on_mount(self) -> None:
+        self.query_one("#mfa-input", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        code = event.value.strip()
+        if not code:
+            self.query_one("#mfa-error", Static).update("Please enter the 6-digit code.")
+            return
+        MFA_FILE.write_text(code + "\n")
+        self.dismiss()
+
+
+class PullProgressScreen(Screen[None]):
+    """Full-screen live progress display for a Garmin data pull or CSV rebuild."""
+
+    BINDINGS = [
+        Binding("b", "back", "Back", show=False),
+        Binding("q", "quit", "Quit", show=True),
+    ]
+
+    CSS = """
+    PullProgressScreen {
+        layout: vertical;
+    }
+
+    #progress-layout {
+        height: 1fr;
+    }
+
+    #log-panel {
+        width: 2fr;
+        border-right: solid $primary-darken-3;
+    }
+
+    #metric-panel {
+        width: 1fr;
+        padding: 0 1;
+        overflow-y: auto;
+    }
+
+    #metric-header {
+        text-style: bold;
+        color: $accent;
+        margin-bottom: 1;
+        height: auto;
+    }
+
+    #metric-subheader {
+        color: $text-muted;
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    #metric-list {
+        height: auto;
+        color: $text;
+    }
+
+    #status-bar {
+        height: 3;
+        padding: 0 1;
+        border-top: solid $primary-darken-3;
+    }
+
+    #progress-bar {
+        width: 1fr;
+        margin: 1 0;
+    }
+
+    #status-label {
+        height: 1;
+        color: $text-muted;
+        text-align: center;
+    }
+    """
+
+    def __init__(
+        self,
+        start_date: str,
+        days: int,
+        label: str,
+        no_skip: bool = False,
+        rebuild_only: bool = False,
+        zip_path: str = "",
+    ) -> None:
+        super().__init__()
+        self._start_date = start_date
+        self._days = days
+        self._label = label
+        self._no_skip = no_skip
+        self._rebuild_only = rebuild_only
+        self._zip_path = zip_path
+
+        self._done = False
+        self._mfa_shown = False
+        self._metric_states: dict[str, str] = {m: "pending" for m in _METRICS}
+        self._overall_done = 0
+        self._per_day_done = 0
+        self._current_date = ""
+        self._total_metrics = days * len(_METRICS) if days > 0 else len(_METRICS)
+
+    # ── layout ────────────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Horizontal(id="progress-layout"):
+            yield RichLog(id="log-panel", highlight=True, markup=True, wrap=True)
+            with Vertical(id="metric-panel"):
+                yield Static(self._label, id="metric-header")
+                yield Static("", id="metric-subheader")
+                yield Static(self._render_metrics(), id="metric-list")
+        with Vertical(id="status-bar"):
+            yield ProgressBar(
+                total=max(self._total_metrics, 1),
+                id="progress-bar",
+                show_eta=False,
+            )
+            yield Static("Starting...", id="status-label")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        cmd = self._build_cmd()
+        self.run_worker(lambda: self._do_pull(cmd), thread=True, name="puller")
+
+    # ── command builder ────────────────────────────────────────────────────────
+
+    def _build_cmd(self) -> list[str]:
+        if self._rebuild_only:
+            return [sys.executable, str(ROOT / "reports" / "build_garmin_csvs.py")]
+        if self._zip_path:
+            return [
+                sys.executable,
+                str(ROOT / "pullers" / "garmin_import_export.py"),
+                "--zip",
+                self._zip_path,
+            ]
+        cmd = [
+            sys.executable,
+            str(ROOT / "pullers" / "garmin.py"),
+            "--date",
+            self._start_date,
+            "--days",
+            str(self._days),
+        ]
+        if self._no_skip:
+            cmd.append("--no-skip")
+        return cmd
+
+    # ── worker (runs in a thread) ──────────────────────────────────────────────
+
+    def _do_pull(self, cmd: list[str]) -> None:
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                cwd=str(ROOT),
+            )
+            assert proc.stdout is not None
+            for raw_line in iter(proc.stdout.readline, ""):
+                line = raw_line.rstrip("\n")
+                self.call_from_thread(self._on_line, line)
+            proc.wait()
+            self.call_from_thread(self._on_done, proc.returncode)
+        except Exception as exc:
+            self.call_from_thread(self._on_error, str(exc))
+
+    # ── UI update helpers (called on main thread via call_from_thread) ─────────
+
+    def _on_line(self, line: str) -> None:
+        log = self.query_one("#log-panel", RichLog)
+        log.write(line)
+
+        stripped = line.strip()
+
+        # New date starting: "[2025-04-06] Pulling 25 metrics..."
+        if stripped.startswith("[") and "] Pulling " in stripped and "metrics" in stripped:
+            try:
+                self._current_date = stripped[1 : stripped.index("]")]
+            except ValueError:
+                pass
+            self._metric_states = {m: "pending" for m in _METRICS}
+            self._per_day_done = 0
+            days_done = self._overall_done // len(_METRICS)
+            subheader = (
+                f"{self._current_date}  ·  Day {days_done + 1} of {self._days}"
+                if self._days > 1
+                else self._current_date
+            )
+            self.query_one("#metric-subheader", Static).update(f"[dim]{subheader}[/]")
+            self._refresh_metric_list()
+            self._set_status(f"Pulling {self._current_date}...")
+            return
+
+        # Metric line: "    ✓    metric_name" or "    ✗ HTTP 404 metric_name"
+        if stripped.startswith("✓") or stripped.startswith("✗"):
+            parts = stripped.split()
+            if parts:
+                metric = parts[-1]
+                if metric in self._metric_states:
+                    state = "done" if stripped.startswith("✓") else "fail"
+                    self._metric_states[metric] = state
+                    self._overall_done += 1
+                    self._per_day_done += 1
+                    self.query_one("#progress-bar", ProgressBar).advance(1)
+                    self._refresh_metric_list()
+                    done = sum(1 for s in self._metric_states.values() if s != "pending")
+                    if self._days > 1:
+                        days_done = self._overall_done // len(_METRICS)
+                        self._set_status(
+                            f"Day {days_done + 1} of {self._days}"
+                            f"  ·  {done}/{len(_METRICS)} metrics"
+                        )
+                    else:
+                        self._set_status(f"{done} / {len(_METRICS)} metrics")
+            return
+
+        # File-based MFA prompt detected (stdin=DEVNULL → non-interactive path)
+        if "Run: echo YOUR_CODE" in stripped and not self._mfa_shown:
+            self._mfa_shown = True
+            self.app.push_screen(_MfaModal())
+            return
+
+        # Already-pulled skip notice
+        if "Already pulled" in stripped and "skipping" in stripped:
+            self._set_status(stripped)
+
+    def _on_done(self, returncode: int) -> None:
+        self._done = True
+        if returncode == 0:
+            self._set_status("Complete  ✓  — press  b  to go back")
+            self.query_one("#log-panel", RichLog).write(
+                "\n[green]Done.[/green]  Press  [bold]b[/bold]  to go back."
+            )
+        else:
+            self._set_status(f"Finished with errors (exit {returncode})  — press  b  to go back")
+            self.query_one("#log-panel", RichLog).write(
+                f"\n[red]Process exited with code {returncode}.[/red]"
+                "  Press  [bold]b[/bold]  to go back."
+            )
+        # Enable the back binding now that the pull is done
+        self._enable_back()
+
+    def _on_error(self, msg: str) -> None:
+        self._done = True
+        self.query_one("#log-panel", RichLog).write(f"\n[red]Error: {msg}[/red]")
+        self._set_status("Error — press  b  to go back")
+        self._enable_back()
+
+    def _refresh_metric_list(self) -> None:
+        self.query_one("#metric-list", Static).update(self._render_metrics())
+
+    def _set_status(self, text: str) -> None:
+        self.query_one("#status-label", Static).update(text)
+
+    def _enable_back(self) -> None:
+        """Swap the Back binding from hidden to visible once the pull is done."""
+        try:
+            self.BINDINGS = [
+                Binding("b", "back", "Back", show=True),
+                Binding("q", "quit", "Quit", show=True),
+            ]
+            self.refresh_bindings()
+        except Exception:
+            pass
+
+    # ── rendering ─────────────────────────────────────────────────────────────
+
+    def _render_metrics(self) -> str:
+        lines: list[str] = []
+        for m in _METRICS:
+            state = self._metric_states[m]
+            label = _LABEL.get(m, m)
+            if state == "done":
+                lines.append(f"[green]✓[/] {label}")
+            elif state == "fail":
+                lines.append(f"[red]✗[/] {label}")
+            else:
+                lines.append(f"[dim]○  {label}[/]")
+        return "\n".join(lines)
+
+    # ── actions ───────────────────────────────────────────────────────────────
+
+    def action_back(self) -> None:
+        if self._done:
+            self.app.pop_screen()
+
+    def action_quit(self) -> None:
+        self.app.exit()

--- a/garmin_extract/screens/stub.py
+++ b/garmin_extract/screens/stub.py
@@ -1,0 +1,71 @@
+"""
+Stub screens for phases not yet built.
+
+Displayed when the user navigates to Setup or Automation from the main
+menu. Replaced by real screens in Phase 3 and Phase 4 respectively.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Static
+
+
+class StubScreen(Screen[None]):
+    """Placeholder for a screen not yet built."""
+
+    BINDINGS = [
+        Binding("b", "back", "Back", show=True),
+        Binding("q", "quit", "Quit", show=True),
+    ]
+
+    CSS = """
+    StubScreen {
+        align: center middle;
+    }
+
+    #stub-box {
+        width: 52;
+        height: auto;
+        border: round $primary;
+        padding: 2 4;
+        content-align: center middle;
+        text-align: center;
+    }
+
+    #stub-title {
+        text-style: bold;
+        color: $text;
+        margin-bottom: 1;
+    }
+
+    #stub-phase {
+        color: $warning;
+        margin-bottom: 1;
+    }
+
+    #stub-hint {
+        color: $text-muted;
+    }
+    """
+
+    def __init__(self, title: str, phase: str) -> None:
+        super().__init__()
+        self._title = title
+        self._phase = phase
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Static(id="stub-box"):
+            yield Static(self._title, id="stub-title")
+            yield Static(f"Coming in {self._phase}", id="stub-phase")
+            yield Static("Press  b  to go back", id="stub-hint")
+        yield Footer()
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_quit(self) -> None:
+        self.app.exit()


### PR DESCRIPTION
## Summary

- **MainMenuScreen** — landing screen routing to Setup (stub) / Pull Data / Automation (stub)
- **DataPullScreen** — submenu with yesterday / 7d / 30d shortcuts, custom date range, full history, zip import, and CSV rebuild
- **PullProgressScreen** — split layout: left RichLog showing raw subprocess output, right panel showing live per-metric checklist (○ → ✓ / ✗) with ProgressBar; MFA modal pops when stdin unavailable (writes to `.mfa_code`); Back binding unlocked only after completion
- **StubScreen** — placeholder for Phase 3 (Initial Setup) and Phase 4 (Automation)
- **app.py** — boots directly into MainMenuScreen; drops Phase 1 placeholder

## Test plan

- [ ] `uv run garmin-extract` launches TUI and shows main menu
- [ ] `1` → Setup stub screen; `b` → back
- [ ] `3` → Automation stub screen; `b` → back
- [ ] `2` → Data Pull submenu; all 7 options visible with correct date ranges
- [ ] `1` (Yesterday) → progress screen launches, subprocess starts, metrics tick off in right panel
- [ ] MFA modal appears if Garmin prompts for MFA (code written to `.mfa_code`)
- [ ] `b` disabled during pull; enabled after completion
- [ ] `4` (Custom) → date/days input; validates bad dates; launches pull
- [ ] `5` (Full history) → start date input; computes day count; launches pull
- [ ] `6` (Import zip) → file path input; validates existence; launches pull
- [ ] `7` (Rebuild CSVs) → launches progress screen in rebuild-only mode
- [ ] `q` quits from any screen
- [ ] `uv run garmin-extract --no-tui` still uses print menu (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)