### PR TITLE
fix: use app.call_from_thread in pull progress worker

### DIFF
--- a/garmin_extract/screens/pull_progress.py
+++ b/garmin_extract/screens/pull_progress.py
@@ -279,11 +279,11 @@ class PullProgressScreen(Screen[None]):
             assert proc.stdout is not None
             for raw_line in iter(proc.stdout.readline, ""):
                 line = raw_line.rstrip("\n")
-                self.call_from_thread(self._on_line, line)
+                self.app.call_from_thread(self._on_line, line)
             proc.wait()
-            self.call_from_thread(self._on_done, proc.returncode)
+            self.app.call_from_thread(self._on_done, proc.returncode)
         except Exception as exc:
-            self.call_from_thread(self._on_error, str(exc))
+            self.app.call_from_thread(self._on_error, str(exc))
 
     # ── UI update helpers (called on main thread via call_from_thread) ─────────
 


### PR DESCRIPTION
## Summary

- `call_from_thread` is a method on `App`, not `Screen` — three calls in `_do_pull` were incorrectly using `self.call_from_thread(...)` instead of `self.app.call_from_thread(...)`
- This caused an immediate `AttributeError` the moment the worker tried to push the first line to the UI

## Test plan

- [ ] `uv run garmin-extract` → Pull Data → Yesterday → progress screen stays alive, log panel streams output, metrics tick off

🤖 Generated with [Claude Code](https://claude.com/claude-code)