### PR TITLE
feat: dynamic metric parsing + per-day row view for multi-day pulls

### DIFF
--- a/garmin_extract/screens/pull_progress.py
+++ b/garmin_extract/screens/pull_progress.py
@@ -1,9 +1,11 @@
-"""Pull progress screen — live metric-by-metric pull with split log panel."""
+"""Pull progress screen — live pull display with dynamic metric parsing."""
 
 from __future__ import annotations
 
 import subprocess
 import sys
+from dataclasses import dataclass
+from datetime import date, timedelta
 from pathlib import Path
 
 from textual.app import ComposeResult
@@ -15,61 +17,8 @@ from textual.widgets import Footer, Header, Input, ProgressBar, RichLog, Static
 ROOT = Path(__file__).parent.parent.parent
 MFA_FILE = ROOT / ".mfa_code"
 
-_METRICS: list[str] = [
-    "stats",
-    "user_summary_chart",
-    "heart_rates",
-    "resting_hr",
-    "hrv",
-    "stress",
-    "body_battery",
-    "body_battery_events",
-    "sleep",
-    "steps",
-    "floors",
-    "spo2",
-    "respiration",
-    "intensity_minutes",
-    "all_day_events",
-    "activities",
-    "weigh_ins",
-    "body_composition",
-    "blood_pressure",
-    "max_metrics",
-    "training_readiness",
-    "training_status",
-    "fitness_age",
-    "hydration",
-    "lifestyle",
-]
 
-_LABEL: dict[str, str] = {
-    "stats": "Daily Summary",
-    "user_summary_chart": "Summary Chart",
-    "heart_rates": "Heart Rate",
-    "resting_hr": "Resting HR",
-    "hrv": "HRV",
-    "stress": "Stress",
-    "body_battery": "Body Battery",
-    "body_battery_events": "BB Events",
-    "sleep": "Sleep",
-    "steps": "Steps",
-    "floors": "Floors",
-    "spo2": "SpO\u2082",
-    "respiration": "Respiration",
-    "intensity_minutes": "Intensity Min",
-    "all_day_events": "All-Day Events",
-    "activities": "Activities",
-    "weigh_ins": "Weigh-Ins",
-    "body_composition": "Body Comp",
-    "blood_pressure": "Blood Pressure",
-    "max_metrics": "Max Metrics",
-    "training_readiness": "Train Ready",
-    "training_status": "Train Status",
-    "fitness_age": "Fitness Age",
-    "hydration": "Hydration",
-    "lifestyle": "Lifestyle",
-}
+# ── MFA modal ─────────────────────────────────────────────────────────────────
 
 
 class _MfaModal(ModalScreen[None]):
@@ -126,6 +75,21 @@ class _MfaModal(ModalScreen[None]):
             return
         MFA_FILE.write_text(code + "\n")
         self.dismiss()
+
+
+# ── day state (multi-day mode) ────────────────────────────────────────────────
+
+
+@dataclass
+class _DayState:
+    date_str: str
+    total: int = 0
+    done: int = 0
+    failed: int = 0
+    status: str = "pending"  # pending | active | done | skipped
+
+
+# ── main screen ───────────────────────────────────────────────────────────────
 
 
 class PullProgressScreen(Screen[None]):
@@ -211,11 +175,23 @@ class PullProgressScreen(Screen[None]):
 
         self._done = False
         self._mfa_shown = False
-        self._metric_states: dict[str, str] = {m: "pending" for m in _METRICS}
-        self._overall_done = 0
-        self._per_day_done = 0
-        self._current_date = ""
-        self._total_metrics = days * len(_METRICS) if days > 0 else len(_METRICS)
+
+        # Determine display mode
+        if days > 1:
+            self._mode = "day"
+            self._day_states: list[_DayState] = self._init_day_states()
+            self._current_day_index: int = -1
+            self._metrics_per_day: int = 0
+        elif days == 1:
+            self._mode = "metric"
+            self._live_metrics: list[tuple[str, str]] = []  # (name, "done"|"fail")
+            self._day_total: int = 0
+            self._day_done: int = 0
+        else:
+            self._mode = "simple"
+
+        self._overall_done: int = 0
+        self._overall_total: int = max(days, 1)  # refined once first day count arrives
 
     # ── layout ────────────────────────────────────────────────────────────────
 
@@ -226,10 +202,10 @@ class PullProgressScreen(Screen[None]):
             with Vertical(id="metric-panel"):
                 yield Static(self._label, id="metric-header")
                 yield Static("", id="metric-subheader")
-                yield Static(self._render_metrics(), id="metric-list")
+                yield Static(self._initial_panel_body(), id="metric-list")
         with Vertical(id="status-bar"):
             yield ProgressBar(
-                total=max(self._total_metrics, 1),
+                total=self._overall_total,
                 id="progress-bar",
                 show_eta=False,
             )
@@ -239,6 +215,15 @@ class PullProgressScreen(Screen[None]):
     def on_mount(self) -> None:
         cmd = self._build_cmd()
         self.run_worker(lambda: self._do_pull(cmd), thread=True, name="puller")
+
+    # ── initial right-panel content ───────────────────────────────────────────
+
+    def _initial_panel_body(self) -> str:
+        if self._mode == "day":
+            return self._render_day_list()
+        if self._mode == "metric":
+            return "[dim]Waiting for first metric...[/]"
+        return "[dim]Starting...[/]"
 
     # ── command builder ────────────────────────────────────────────────────────
 
@@ -264,7 +249,19 @@ class PullProgressScreen(Screen[None]):
             cmd.append("--no-skip")
         return cmd
 
-    # ── worker (runs in a thread) ──────────────────────────────────────────────
+    # ── pre-compute day state list ────────────────────────────────────────────
+
+    def _init_day_states(self) -> list[_DayState]:
+        states: list[_DayState] = []
+        try:
+            start = date.fromisoformat(self._start_date)
+            for i in range(self._days):
+                states.append(_DayState((start + timedelta(days=i)).isoformat()))
+        except ValueError:
+            pass
+        return states
+
+    # ── worker (thread) ────────────────────────────────────────────────────────
 
     def _do_pull(self, cmd: list[str]) -> None:
         try:
@@ -285,96 +282,189 @@ class PullProgressScreen(Screen[None]):
         except Exception as exc:
             self.app.call_from_thread(self._on_error, str(exc))
 
-    # ── UI update helpers (called on main thread via call_from_thread) ─────────
+    # ── line parser (main thread) ──────────────────────────────────────────────
 
     def _on_line(self, line: str) -> None:
-        log = self.query_one("#log-panel", RichLog)
-        log.write(line)
-
+        self.query_one("#log-panel", RichLog).write(line)
         stripped = line.strip()
 
-        # New date starting: "[2025-04-06] Pulling 25 metrics..."
+        # ── "[2025-04-06] Pulling N metrics..." ──
         if stripped.startswith("[") and "] Pulling " in stripped and "metrics" in stripped:
-            try:
-                self._current_date = stripped[1 : stripped.index("]")]
-            except ValueError:
-                pass
-            self._metric_states = {m: "pending" for m in _METRICS}
-            self._per_day_done = 0
-            days_done = self._overall_done // len(_METRICS)
-            subheader = (
-                f"{self._current_date}  ·  Day {days_done + 1} of {self._days}"
-                if self._days > 1
-                else self._current_date
-            )
-            self.query_one("#metric-subheader", Static).update(f"[dim]{subheader}[/]")
-            self._refresh_metric_list()
-            self._set_status(f"Pulling {self._current_date}...")
+            self._handle_day_start(stripped)
             return
 
-        # Metric line: "    ✓    metric_name" or "    ✗ HTTP 404 metric_name"
+        # ── "[2025-04-06] Already pulled — skipping" ──
+        if "Already pulled" in stripped and "skipping" in stripped:
+            self._handle_day_skipped(stripped)
+            return
+
+        # ── "    ✓/✗  metric_name" ──
         if stripped.startswith("✓") or stripped.startswith("✗"):
-            parts = stripped.split()
-            if parts:
-                metric = parts[-1]
-                if metric in self._metric_states:
-                    state = "done" if stripped.startswith("✓") else "fail"
-                    self._metric_states[metric] = state
-                    self._overall_done += 1
-                    self._per_day_done += 1
-                    self.query_one("#progress-bar", ProgressBar).advance(1)
-                    self._refresh_metric_list()
-                    done = sum(1 for s in self._metric_states.values() if s != "pending")
-                    if self._days > 1:
-                        days_done = self._overall_done // len(_METRICS)
-                        self._set_status(
-                            f"Day {days_done + 1} of {self._days}"
-                            f"  ·  {done}/{len(_METRICS)} metrics"
-                        )
-                    else:
-                        self._set_status(f"{done} / {len(_METRICS)} metrics")
+            self._handle_metric_line(stripped)
             return
 
-        # File-based MFA prompt detected (stdin=DEVNULL → non-interactive path)
+        # ── file-based MFA prompt ──
         if "Run: echo YOUR_CODE" in stripped and not self._mfa_shown:
             self._mfa_shown = True
             self.app.push_screen(_MfaModal())
+
+    def _handle_day_start(self, stripped: str) -> None:
+        try:
+            date_str = stripped[1 : stripped.index("]")]
+            # Parse metric count from "Pulling N metrics..."
+            parts = stripped.split()
+            count_idx = next((i for i, p in enumerate(parts) if p == "Pulling"), -1)
+            n_metrics = int(parts[count_idx + 1]) if count_idx >= 0 else 0
+        except (ValueError, IndexError):
             return
 
-        # Already-pulled skip notice
-        if "Already pulled" in stripped and "skipping" in stripped:
-            self._set_status(stripped)
+        if self._mode == "day":
+            # Find matching day state
+            idx = next(
+                (i for i, s in enumerate(self._day_states) if s.date_str == date_str),
+                -1,
+            )
+            if idx == -1:
+                self._day_states.append(_DayState(date_str))
+                idx = len(self._day_states) - 1
+            self._current_day_index = idx
+            self._day_states[idx].status = "active"
+            self._day_states[idx].total = n_metrics
+
+            if self._metrics_per_day == 0 and n_metrics > 0:
+                # First real count — set progress bar total
+                self._metrics_per_day = n_metrics
+                self._overall_total = self._days * n_metrics
+                self.query_one("#progress-bar", ProgressBar).total = self._overall_total
+
+            self._refresh_day_list()
+            self._set_status(f"Day {idx + 1} of {self._days}  ·  {date_str}")
+
+        elif self._mode == "metric":
+            self._day_total = n_metrics
+            self._day_done = 0
+            self._live_metrics = []
+            if n_metrics > 0:
+                self.query_one("#progress-bar", ProgressBar).total = n_metrics
+            self.query_one("#metric-subheader", Static).update(f"[dim]{date_str}[/]")
+            self._refresh_metric_list()
+            self._set_status(f"Pulling {date_str}...")
+
+    def _handle_day_skipped(self, stripped: str) -> None:
+        try:
+            date_str = stripped[1 : stripped.index("]")]
+        except ValueError:
+            return
+
+        if self._mode == "day":
+            idx = next(
+                (i for i, s in enumerate(self._day_states) if s.date_str == date_str),
+                -1,
+            )
+            if idx >= 0:
+                self._day_states[idx].status = "skipped"
+                # Advance progress by one day's worth of metrics (or 1 if unknown)
+                advance = self._metrics_per_day if self._metrics_per_day else 1
+                self._overall_done += advance
+                self.query_one("#progress-bar", ProgressBar).advance(advance)
+                self._refresh_day_list()
+                self._set_status(f"Skipped {date_str}  (already pulled)")
+
+    def _handle_metric_line(self, stripped: str) -> None:
+        parts = stripped.split()
+        if not parts:
+            return
+        metric_name = parts[-1]
+        is_ok = stripped.startswith("✓")
+        state = "done" if is_ok else "fail"
+
+        if self._mode == "metric":
+            self._live_metrics.append((metric_name, state))
+            self._day_done += 1
+            self.query_one("#progress-bar", ProgressBar).advance(1)
+            self._refresh_metric_list()
+            self._set_status(f"{self._day_done} / {self._day_total or '?'} metrics")
+
+        elif self._mode == "day" and self._current_day_index >= 0:
+            ds = self._day_states[self._current_day_index]
+            if is_ok:
+                ds.done += 1
+            else:
+                ds.failed += 1
+            self._overall_done += 1
+            self.query_one("#progress-bar", ProgressBar).advance(1)
+
+            # Day complete when done + failed == total
+            if ds.total > 0 and (ds.done + ds.failed) >= ds.total:
+                ds.status = "done"
+
+            self._refresh_day_list()
+            self._set_status(
+                f"Day {self._current_day_index + 1} of {self._days}"
+                f"  ·  {ds.done + ds.failed}/{ds.total or '?'} metrics"
+            )
+
+    # ── completion / error ─────────────────────────────────────────────────────
 
     def _on_done(self, returncode: int) -> None:
         self._done = True
+        log = self.query_one("#log-panel", RichLog)
         if returncode == 0:
-            self._set_status("Complete  ✓  — press  b  to go back")
-            self.query_one("#log-panel", RichLog).write(
-                "\n[green]Done.[/green]  Press  [bold]b[/bold]  to go back."
-            )
+            self._set_status("Complete ✓  —  press  b  to go back")
+            log.write("\n[green]Done.[/green]  Press  [bold]b[/bold]  to go back.")
         else:
-            self._set_status(f"Finished with errors (exit {returncode})  — press  b  to go back")
-            self.query_one("#log-panel", RichLog).write(
+            self._set_status(f"Finished with errors (exit {returncode})  —  press  b  to go back")
+            log.write(
                 f"\n[red]Process exited with code {returncode}.[/red]"
                 "  Press  [bold]b[/bold]  to go back."
             )
-        # Enable the back binding now that the pull is done
         self._enable_back()
 
     def _on_error(self, msg: str) -> None:
         self._done = True
         self.query_one("#log-panel", RichLog).write(f"\n[red]Error: {msg}[/red]")
-        self._set_status("Error — press  b  to go back")
+        self._set_status("Error  —  press  b  to go back")
         self._enable_back()
 
+    # ── rendering ─────────────────────────────────────────────────────────────
+
+    def _render_day_list(self) -> str:
+        lines: list[str] = []
+        for ds in self._day_states:
+            if ds.status == "done":
+                count = f"({ds.done}/{ds.total})" if ds.total else ""
+                failed = f"  [red]{ds.failed} failed[/]" if ds.failed else ""
+                lines.append(f"[green]✓[/] {ds.date_str}  [dim]{count}[/]{failed}")
+            elif ds.status == "active":
+                count = f"{ds.done + ds.failed}/{ds.total}" if ds.total else "…"
+                lines.append(f"[yellow]●[/] {ds.date_str}  [dim]({count})[/]")
+            elif ds.status == "skipped":
+                lines.append(f"[dim]↷ {ds.date_str}  (skipped)[/]")
+            else:
+                lines.append(f"[dim]○  {ds.date_str}[/]")
+        return "\n".join(lines)
+
+    def _render_metric_list(self) -> str:
+        if not self._live_metrics:
+            return "[dim]Waiting for first metric...[/]"
+        lines: list[str] = []
+        for name, state in self._live_metrics:
+            if state == "done":
+                lines.append(f"[green]✓[/] {name}")
+            else:
+                lines.append(f"[red]✗[/] {name}")
+        return "\n".join(lines)
+
+    def _refresh_day_list(self) -> None:
+        self.query_one("#metric-list", Static).update(self._render_day_list())
+
     def _refresh_metric_list(self) -> None:
-        self.query_one("#metric-list", Static).update(self._render_metrics())
+        self.query_one("#metric-list", Static).update(self._render_metric_list())
 
     def _set_status(self, text: str) -> None:
         self.query_one("#status-label", Static).update(text)
 
     def _enable_back(self) -> None:
-        """Swap the Back binding from hidden to visible once the pull is done."""
         try:
             self.BINDINGS = [
                 Binding("b", "back", "Back", show=True),
@@ -383,21 +473,6 @@ class PullProgressScreen(Screen[None]):
             self.refresh_bindings()
         except Exception:
             pass
-
-    # ── rendering ─────────────────────────────────────────────────────────────
-
-    def _render_metrics(self) -> str:
-        lines: list[str] = []
-        for m in _METRICS:
-            state = self._metric_states[m]
-            label = _LABEL.get(m, m)
-            if state == "done":
-                lines.append(f"[green]✓[/] {label}")
-            elif state == "fail":
-                lines.append(f"[red]✗[/] {label}")
-            else:
-                lines.append(f"[dim]○  {label}[/]")
-        return "\n".join(lines)
 
     # ── actions ───────────────────────────────────────────────────────────────
 

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -423,7 +423,96 @@ def build_metrics(sb, d: date, display_name: str, uuid: str = "") -> list:
         ("fitness_age", f"/fitnessage-service/fitnessage/{cdate}", {}),
         ("hydration", f"/usersummary-service/usersummary/hydration/daily/{cdate}", {}),
         ("lifestyle", f"/lifestylelogging-service/dailyLog/{cdate}", {}),
+        # Nutrition
+        ("nutrition_food_log", f"/nutrition-service/food/logs/{cdate}", {}),
+        ("nutrition_meals", f"/nutrition-service/meals/{cdate}", {}),
+        # Reproductive health (empty for users without data — handled gracefully)
+        ("menstrual_cycle", f"/periodichealth-service/menstrualcycle/dayview/{cdate}", {}),
     ]
+
+
+# ---------------------------------------------------------------------------
+# Per-activity detail metrics
+# ---------------------------------------------------------------------------
+
+
+def build_activity_metrics(activity_id: str) -> list:
+    """Return per-activity detail endpoints for a single activity ID."""
+    base = f"/activity-service/activity/{activity_id}"
+    return [
+        (f"activity_{activity_id}_detail", base, {}),
+        (f"activity_{activity_id}_splits", f"{base}/splits", {}),
+        (f"activity_{activity_id}_typed_splits", f"{base}/typedsplits", {}),
+        (f"activity_{activity_id}_split_summaries", f"{base}/split_summaries", {}),
+        (f"activity_{activity_id}_hr_timezones", f"{base}/hrTimeInZones", {}),
+        (f"activity_{activity_id}_power_timezones", f"{base}/powerTimeInZones", {}),
+        (f"activity_{activity_id}_exercise_sets", f"{base}/exerciseSets", {}),
+        (f"activity_{activity_id}_weather", f"{base}/weather", {}),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Static / profile metrics (pulled once per session, not per date)
+# ---------------------------------------------------------------------------
+
+
+def build_profile_metrics(display_name: str, user_profile_number: str = "") -> list:
+    """Return static endpoints that don't change per date."""
+    metrics = [
+        ("user_profile", "/userprofile-service/userprofile/user-settings", {}),
+        ("devices", "/device-service/deviceregistration/devices", {}),
+        ("primary_training_device", "/web-gateway/device-info/primary-training-device", {}),
+        (
+            "personal_records",
+            f"/personalrecord-service/personalrecord/prs/{display_name}",
+            {},
+        ),
+        ("training_plans", "/trainingplan-service/trainingplan/plans", {}),
+        ("workouts", "/workout-service/workouts", {"start": 0, "limit": 100}),
+    ]
+    if user_profile_number:
+        metrics.append(
+            ("gear", "/gear-service/gear/filterGear", {"userProfilePk": user_profile_number})
+        )
+    else:
+        metrics.append(("gear", "/gear-service/gear/filterGear", {}))
+    return metrics
+
+
+def pull_profile_data(sb, display_name: str) -> None:
+    """Pull static profile/device/gear data once per session and save to profile.json."""
+    # First pull user_profile to try to get the profile number for gear
+    user_profile_number = ""
+    try:
+        result = browser_fetch(sb, "/userprofile-service/userprofile/user-settings", None)
+        if result.get("ok") and result.get("data"):
+            data = result["data"]
+            user_profile_number = str(
+                data.get("userProfileNumber") or data.get("id") or data.get("profileId") or ""
+            )
+    except Exception:
+        pass
+
+    metrics = build_profile_metrics(display_name, user_profile_number)
+    print(f"Profile data: Pulling {len(metrics)} items...")
+    pad = max(len(name) for name, _, _ in metrics)
+    results: dict = {}
+
+    for name, path, params in metrics:
+        try:
+            result = browser_fetch(sb, path, params or None)
+            results[name] = result.get("data") if result.get("ok") else result
+            status = "✓" if result.get("ok") else f"✗ HTTP {result.get('status')}"
+        except Exception as e:
+            results[name] = {"_error": str(e)}
+            status = f"✗ {e}"
+        print(f"    {status:<4} {name:<{pad}}")
+
+    out_path = DATA_DIR / "profile.json"
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(results, f, indent=2, default=str)
+    print(f"  → {out_path}\n")
 
 
 # ---------------------------------------------------------------------------
@@ -446,7 +535,45 @@ def pull_date(sb, d: date, display_name: str, uuid: str = "") -> dict:
             status = f"✗ {e}"
         print(f"    {status:<4} {name:<{pad}}")
 
+    # Per-activity detail: iterate over activity IDs from the activities response
+    activity_ids = _extract_activity_ids(results.get("activities"))
+    if activity_ids:
+        n = len(activity_ids)
+        print(f"    Fetching detail for {n} activit{'y' if n == 1 else 'ies'}...")
+        for aid in activity_ids:
+            for det_name, det_path, det_params in build_activity_metrics(str(aid)):
+                try:
+                    det_result = browser_fetch(sb, det_path, det_params or None)
+                    results[det_name] = (
+                        det_result.get("data") if det_result.get("ok") else det_result
+                    )
+                    status = "✓" if det_result.get("ok") else f"✗ HTTP {det_result.get('status')}"
+                except Exception as e:
+                    results[det_name] = {"_error": str(e)}
+                    status = f"✗ {e}"
+                print(f"    {status:<4} {det_name:<{pad}}")
+
     return results
+
+
+def _extract_activity_ids(activities_data) -> list:
+    """Extract activity IDs from the activities API response."""
+    if not activities_data:
+        return []
+    # Response is either a list of activity objects or a dict with a list inside
+    if isinstance(activities_data, list):
+        items = activities_data
+    elif isinstance(activities_data, dict):
+        items = activities_data.get("activityList") or activities_data.get("activities") or []
+    else:
+        return []
+    ids = []
+    for item in items:
+        if isinstance(item, dict):
+            aid = item.get("activityId") or item.get("id")
+            if aid:
+                ids.append(str(aid))
+    return ids
 
 
 # ---------------------------------------------------------------------------
@@ -512,6 +639,8 @@ def main():
                 print("ERROR: Could not retrieve display name — login may have failed.")
                 sys.exit(1)
             print(f"Logged in as: {display_name} (uuid={uuid or 'unknown'})\n")
+
+            pull_profile_data(sb, display_name)
 
             for d in dates:
                 out_path = DATA_DIR / f"{d.isoformat()}.json"


### PR DESCRIPTION
## Summary

Closes #5, closes #6

- **Drop hardcoded `_METRICS` / `_LABEL` lists** — the TUI no longer maintains a parallel list of metric names; all state is derived from subprocess output lines
- **Three display modes** driven by the `days` param passed to `PullProgressScreen`:
  - `days > 1` → right panel shows one row per day (`○` → `●` → `✓`) with a live `done/total` count; no per-metric expansion
  - `days == 1` → right panel builds a metric list dynamically as `✓/✗` lines arrive; the list grows in real time
  - `days == 0` → rebuild / zip import; log-only, no metric panel
- **Day rows pre-computed** from `start_date + days` so the full day list is visible upfront; "Already pulled" days flip to `↷ (skipped)`
- **Progress bar total** set from first parsed `Pulling N metrics...` line — no hardcoded `25`

## Test plan

- [ ] Yesterday pull → metric mode: right panel builds metric list one row at a time as ✓/✗ arrive
- [ ] Last 7 days / Last 30 days → day mode: right panel shows all day rows upfront, `●` tracks current day with count, `✓` on completion
- [ ] Skipped days (already pulled) show `↷` in day list
- [ ] Progress bar advances correctly in both modes
- [ ] Rebuild CSVs → simple mode: log panel only, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)