### PR TITLE
fix: use python -u for all subprocess calls to prevent output buffering

### DIFF
--- a/garmin_extract/screens/pull_progress.py
+++ b/garmin_extract/screens/pull_progress.py
@@ -229,16 +229,18 @@ class PullProgressScreen(Screen[None]):
 
     def _build_cmd(self) -> list[str]:
         if self._rebuild_only:
-            return [sys.executable, str(ROOT / "reports" / "build_garmin_csvs.py")]
+            return [sys.executable, "-u", str(ROOT / "reports" / "build_garmin_csvs.py")]
         if self._zip_path:
             return [
                 sys.executable,
+                "-u",
                 str(ROOT / "pullers" / "garmin_import_export.py"),
                 "--zip",
                 self._zip_path,
             ]
         cmd = [
             sys.executable,
+            "-u",
             str(ROOT / "pullers" / "garmin.py"),
             "--date",
             self._start_date,

--- a/garmin_extract/screens/setup.py
+++ b/garmin_extract/screens/setup.py
@@ -777,7 +777,7 @@ class GmailSetupScreen(Screen[None]):
 
         try:
             proc = subprocess.Popen(
-                [sys.executable, str(ROOT / "scripts" / "setup_gmail_auth.py")],
+                [sys.executable, "-u", str(ROOT / "scripts" / "setup_gmail_auth.py")],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary

When Python's stdout is piped (not a TTY), it switches to 4096-byte block buffering. All subprocess calls in the TUI were affected — output sat in the buffer and never reached the log panel until the buffer filled or the process ended.

**Symptom:** `GmailSetupScreen` stuck on "Running authorization flow…" — the auth URL never appeared, the code modal never showed, and the script silently timed out after 5 minutes.

**Fix:** Added `-u` (force unbuffered stdout/stderr) to all three subprocess command builders:
- `GmailSetupScreen` → `setup_gmail_auth.py`
- `PullProgressScreen` → `garmin.py`, `build_garmin_csvs.py`, `garmin_import_export.py`

## Test plan

- [ ] Initial Setup → Gmail MFA → auth URL appears in log panel immediately
- [ ] Code modal pops when "Waiting up to" line is detected
- [ ] Pull Data → Yesterday → metric lines stream in real time (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)