### PR TITLE
feat: Phase 5 — Google Drive / Sheets export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ reports/*.csv
 .mfa_code
 .gmail_auth_code
 
+# Drive/Sheets config (local state — folder ID, sheet ID, last export)
+.drive_config.json
+
 # Logs
 *.log
 logs/

--- a/garmin_extract/_google_drive.py
+++ b/garmin_extract/_google_drive.py
@@ -1,0 +1,281 @@
+"""
+Google Drive and Sheets helpers for Phase 5 export.
+
+All functions are pure API calls with no Textual dependency — safe to call
+from a worker thread. Credentials are loaded from .google_token.json (the
+same token written by scripts/setup_gmail_auth.py).
+
+State (folder_id, sheet_id, last_export) is persisted in .drive_config.json
+at the project root so subsequent exports update the same resources.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).parent.parent
+TOKEN_FILE = ROOT / ".google_token.json"
+CREDENTIALS_FILE = ROOT / "google_credentials.json"
+CONFIG_FILE = ROOT / ".drive_config.json"
+
+REQUIRED_SCOPES = {
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/spreadsheets",
+}
+
+DAILY_CSV = ROOT / "reports" / "garmin_daily.csv"
+ACTIVITIES_CSV = ROOT / "reports" / "garmin_activities.csv"
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def _load_credentials():
+    """Return refreshed google.oauth2.credentials.Credentials, or raise."""
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+
+    if not TOKEN_FILE.exists():
+        raise FileNotFoundError("No OAuth token found — run Gmail OAuth setup first.")
+
+    tok = json.loads(TOKEN_FILE.read_text())
+    creds = Credentials(
+        token=tok.get("token"),
+        refresh_token=tok.get("refresh_token"),
+        token_uri=tok.get("token_uri"),
+        client_id=tok.get("client_id"),
+        client_secret=tok.get("client_secret"),
+        scopes=tok.get("scopes"),
+    )
+
+    if creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+        tok["token"] = creds.token
+        TOKEN_FILE.write_text(json.dumps(tok, indent=2))
+
+    return creds
+
+
+def check_auth() -> tuple[str, str]:
+    """Return (status, detail) — status is 'ok' | 'missing_scopes' | 'no_token' | 'error'."""
+    if not TOKEN_FILE.exists():
+        return "no_token", "No OAuth token — run Gmail OAuth setup first."
+
+    try:
+        tok = json.loads(TOKEN_FILE.read_text())
+        token_scopes = set(tok.get("scopes") or [])
+        missing = REQUIRED_SCOPES - token_scopes
+        if missing:
+            return (
+                "missing_scopes",
+                "Token lacks Drive/Sheets scopes — re-run Gmail OAuth setup to upgrade.",
+            )
+        creds = _load_credentials()
+        if not creds.valid and not creds.refresh_token:
+            return "error", "Token is expired and cannot be refreshed."
+        return "ok", "Drive and Sheets access authorized."
+    except Exception as exc:
+        return "error", str(exc)
+
+
+# ---------------------------------------------------------------------------
+# Config persistence
+# ---------------------------------------------------------------------------
+
+
+def load_config() -> dict[str, Any]:
+    """Load .drive_config.json, returning {} if not found."""
+    if not CONFIG_FILE.exists():
+        return {}
+    try:
+        return json.loads(CONFIG_FILE.read_text())
+    except Exception:
+        return {}
+
+
+def save_config(cfg: dict[str, Any]) -> None:
+    """Write config dict to .drive_config.json."""
+    CONFIG_FILE.write_text(json.dumps(cfg, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Drive helpers
+# ---------------------------------------------------------------------------
+
+
+def _drive_service(creds):
+    from googleapiclient.discovery import build
+
+    return build("drive", "v3", credentials=creds, cache_discovery=False)
+
+
+def _sheets_service(creds):
+    from googleapiclient.discovery import build
+
+    return build("sheets", "v4", credentials=creds, cache_discovery=False)
+
+
+def get_or_create_folder(creds, name: str = "Garmin Extract") -> str:
+    """Return the Drive folder ID for *name*, creating it if absent."""
+    svc = _drive_service(creds)
+
+    # Search for existing folder by name
+    q = f"name='{name}' and mimeType='application/vnd.google-apps.folder' and trashed=false"
+    results = svc.files().list(q=q, fields="files(id, name)", pageSize=1).execute()
+    files = results.get("files", [])
+    if files:
+        return files[0]["id"]
+
+    # Create it
+    meta = {"name": name, "mimeType": "application/vnd.google-apps.folder"}
+    folder = svc.files().create(body=meta, fields="id").execute()
+    return folder["id"]
+
+
+def upload_csv(creds, csv_path: Path, folder_id: str) -> tuple[str, str]:
+    """
+    Upload *csv_path* to *folder_id*, updating in-place if it already exists.
+    Returns (file_id, web_link).
+    """
+    from googleapiclient.http import MediaFileUpload
+
+    svc = _drive_service(creds)
+    name = csv_path.name
+    mime = "text/csv"
+
+    # Check if file already exists in folder
+    q = f"name='{name}' and '{folder_id}' in parents and trashed=false"
+    results = svc.files().list(q=q, fields="files(id)", pageSize=1).execute()
+    existing = results.get("files", [])
+
+    media = MediaFileUpload(str(csv_path), mimetype=mime, resumable=False)
+
+    if existing:
+        file_id = existing[0]["id"]
+        svc.files().update(fileId=file_id, media_body=media).execute()
+    else:
+        meta = {"name": name, "parents": [folder_id]}
+        f = svc.files().create(body=meta, media_body=media, fields="id").execute()
+        file_id = f["id"]
+
+    # Make readable link
+    link = f"https://drive.google.com/file/d/{file_id}/view"
+    return file_id, link
+
+
+def upload_csvs_to_drive() -> dict[str, Any]:
+    """
+    Upload garmin_daily.csv and garmin_activities.csv to Drive.
+    Returns a result dict with keys: ok, folder_link, files, error.
+    """
+    missing = [p.name for p in (DAILY_CSV, ACTIVITIES_CSV) if not p.exists()]
+    if missing:
+        joined = ", ".join(missing)
+        return {"ok": False, "error": f"CSVs not found: {joined}. Run 'Pull Data' first."}
+
+    try:
+        creds = _load_credentials()
+        cfg = load_config()
+
+        folder_id = cfg.get("folder_id") or get_or_create_folder(creds)
+        cfg["folder_id"] = folder_id
+
+        files = []
+        for csv_path in (DAILY_CSV, ACTIVITIES_CSV):
+            file_id, link = upload_csv(creds, csv_path, folder_id)
+            files.append({"name": csv_path.name, "id": file_id, "link": link})
+
+        cfg["last_export"] = datetime.now(timezone.utc).isoformat()
+        save_config(cfg)
+
+        folder_link = f"https://drive.google.com/drive/folders/{folder_id}"
+        return {"ok": True, "folder_link": folder_link, "files": files, "error": None}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Sheets helpers
+# ---------------------------------------------------------------------------
+
+
+def _csv_to_values(csv_path: Path) -> list[list[str]]:
+    """Read a CSV file and return it as a list-of-lists for the Sheets API."""
+    with open(csv_path, newline="") as f:
+        return [row for row in csv.reader(f)]
+
+
+def _ensure_sheet_tab(sheets_svc, spreadsheet_id: str, tab_name: str) -> None:
+    """Add a tab named *tab_name* if it doesn't already exist."""
+    meta = sheets_svc.spreadsheets().get(spreadsheetId=spreadsheet_id).execute()
+    existing = {s["properties"]["title"] for s in meta.get("sheets", [])}
+    if tab_name not in existing:
+        body = {"requests": [{"addSheet": {"properties": {"title": tab_name}}}]}
+        sheets_svc.spreadsheets().batchUpdate(spreadsheetId=spreadsheet_id, body=body).execute()
+
+
+def sync_to_sheets() -> dict[str, Any]:
+    """
+    Create or update a Google Sheet with Daily and Activities tabs.
+    Returns a result dict with keys: ok, sheet_url, error.
+    """
+    missing = [p.name for p in (DAILY_CSV, ACTIVITIES_CSV) if not p.exists()]
+    if missing:
+        joined = ", ".join(missing)
+        return {"ok": False, "error": f"CSVs not found: {joined}. Run 'Pull Data' first."}
+
+    try:
+        creds = _load_credentials()
+        svc = _sheets_service(creds)
+        cfg = load_config()
+
+        sheet_id = cfg.get("sheet_id")
+
+        if not sheet_id:
+            # Create new spreadsheet
+            body = {
+                "properties": {"title": "Garmin Data"},
+                "sheets": [
+                    {"properties": {"title": "Daily"}},
+                    {"properties": {"title": "Activities"}},
+                ],
+            }
+            result = svc.spreadsheets().create(body=body, fields="spreadsheetId").execute()
+            sheet_id = result["spreadsheetId"]
+            cfg["sheet_id"] = sheet_id
+        else:
+            # Ensure both tabs exist
+            _ensure_sheet_tab(svc, sheet_id, "Daily")
+            _ensure_sheet_tab(svc, sheet_id, "Activities")
+
+        tab_map = {"Daily": DAILY_CSV, "Activities": ACTIVITIES_CSV}
+        data = []
+        for tab, csv_path in tab_map.items():
+            values = _csv_to_values(csv_path)
+            data.append({"range": f"'{tab}'!A1", "values": values})
+
+        # Clear existing data in both tabs first
+        svc.spreadsheets().values().batchClear(
+            spreadsheetId=sheet_id,
+            body={"ranges": [f"'{t}'!A:ZZZ" for t in tab_map]},
+        ).execute()
+
+        # Write fresh data
+        svc.spreadsheets().values().batchUpdate(
+            spreadsheetId=sheet_id,
+            body={"valueInputOption": "RAW", "data": data},
+        ).execute()
+
+        cfg["last_export"] = datetime.now(timezone.utc).isoformat()
+        save_config(cfg)
+
+        sheet_url = f"https://docs.google.com/spreadsheets/d/{sheet_id}/edit"
+        return {"ok": True, "sheet_url": sheet_url, "error": None}
+    except Exception as exc:
+        return {"ok": False, "error": str(exc)}

--- a/garmin_extract/screens/automation.py
+++ b/garmin_extract/screens/automation.py
@@ -185,9 +185,9 @@ class AutomationScreen(Screen[None]):
         self.app.push_screen(CronScreen())
 
     def action_go_sheets(self) -> None:
-        from garmin_extract.screens.stub import StubScreen
+        from garmin_extract.screens.drive_sheets import DriveSheetsScreen
 
-        self.app.push_screen(StubScreen("Google Drive / Sheets", "Phase 5"))
+        self.app.push_screen(DriveSheetsScreen())
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/garmin_extract/screens/drive_sheets.py
+++ b/garmin_extract/screens/drive_sheets.py
@@ -1,0 +1,198 @@
+"""Google Drive / Sheets export screen — Phase 5."""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Static
+
+_MENU = """\
+
+  ┌─────────────────────────────────────────────────────┐
+  │                                                     │
+  │   [1]  Upload CSVs to Drive                         │
+  │        Upload garmin_daily.csv + activities.csv     │
+  │                                                     │
+  │   [2]  Sync to Google Sheets                        │
+  │        Create / update a Garmin Data spreadsheet    │
+  │                                                     │
+  │   [3]  Both (Drive + Sheets)                        │
+  │        Upload CSVs and sync spreadsheet             │
+  │                                                     │
+  └─────────────────────────────────────────────────────┘\
+"""
+
+
+class DriveSheetsScreen(Screen[None]):
+    """Google Drive / Sheets export landing screen."""
+
+    BINDINGS = [
+        Binding("1", "do_drive", "Upload to Drive", show=False),
+        Binding("2", "do_sheets", "Sync to Sheets", show=False),
+        Binding("3", "do_both", "Both", show=False),
+        Binding("b", "back", "Back", show=True),
+        Binding("q", "quit", "Quit", show=True),
+    ]
+
+    CSS = """
+    DriveSheetsScreen {
+        layout: vertical;
+        padding: 2 4;
+    }
+
+    #ds-header {
+        text-style: bold;
+        color: $accent;
+        margin-bottom: 1;
+    }
+
+    #ds-auth {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    #ds-last {
+        color: $text-muted;
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    #ds-menu {
+        width: 57;
+        color: $text;
+    }
+
+    #ds-hint {
+        width: 57;
+        text-align: center;
+        color: $text-muted;
+        margin-top: 1;
+    }
+
+    #ds-status {
+        height: auto;
+        margin-top: 1;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield Static("Google Drive / Sheets", id="ds-header")
+        yield Static("Checking authorization…", id="ds-auth")
+        yield Static("", id="ds-last")
+        yield Static(_MENU, id="ds-menu")
+        yield Static("Press  1  2  3  to select  ·  b  to go back", id="ds-hint")
+        yield Static("", id="ds-status")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.run_worker(self._check_auth, thread=True, name="ds-auth-check")
+
+    def on_screen_resume(self) -> None:
+        self.run_worker(self._check_auth, thread=True, name="ds-auth-check")
+
+    # ── auth status ──────────────────────────────────────────────────────────
+
+    def _check_auth(self) -> None:
+        from garmin_extract._google_drive import check_auth, load_config
+
+        status, detail = check_auth()
+        cfg = load_config()
+        last = cfg.get("last_export")
+
+        if status == "ok":
+            auth_text = "[green]✓[/] Drive and Sheets authorized"
+        elif status == "missing_scopes":
+            auth_text = f"[yellow]⚠[/]  {detail}"
+        else:
+            auth_text = f"[red]✗[/]  {detail}"
+
+        last_text = ""
+        if last:
+            try:
+                from datetime import datetime
+
+                dt = datetime.fromisoformat(last).astimezone(None)  # local timezone
+                last_text = f"Last export: {dt.strftime('%Y-%m-%d %H:%M')}"
+            except Exception:
+                last_text = f"Last export: {last[:19]}"
+
+        self.app.call_from_thread(self._apply_auth, auth_text, last_text)
+
+    def _apply_auth(self, auth_text: str, last_text: str) -> None:
+        self.query_one("#ds-auth", Static).update(auth_text)
+        self.query_one("#ds-last", Static).update(last_text)
+
+    # ── actions ──────────────────────────────────────────────────────────────
+
+    def _set_status(self, text: str) -> None:
+        self.query_one("#ds-status", Static).update(text)
+
+    def action_do_drive(self) -> None:
+        self._set_status("[dim]Uploading CSVs to Drive…[/]")
+        self.run_worker(self._run_drive, thread=True, exclusive=True, name="ds-drive")
+
+    def action_do_sheets(self) -> None:
+        self._set_status("[dim]Syncing to Google Sheets…[/]")
+        self.run_worker(self._run_sheets, thread=True, exclusive=True, name="ds-sheets")
+
+    def action_do_both(self) -> None:
+        self._set_status("[dim]Uploading CSVs and syncing Sheets…[/]")
+        self.run_worker(self._run_both, thread=True, exclusive=True, name="ds-both")
+
+    # ── workers ──────────────────────────────────────────────────────────────
+
+    def _run_drive(self) -> None:
+        from garmin_extract._google_drive import upload_csvs_to_drive
+
+        result = upload_csvs_to_drive()
+        if result["ok"]:
+            names = "  ·  ".join(f["name"] for f in result["files"])
+            text = f"[green]✓[/] Uploaded: {names}\n[dim]{result['folder_link']}[/]"
+        else:
+            text = f"[red]✗[/]  {result['error']}"
+        self.app.call_from_thread(self._apply_result, text)
+
+    def _run_sheets(self) -> None:
+        from garmin_extract._google_drive import sync_to_sheets
+
+        result = sync_to_sheets()
+        if result["ok"]:
+            text = f"[green]✓[/] Google Sheet updated\n[dim]{result['sheet_url']}[/]"
+        else:
+            text = f"[red]✗[/]  {result['error']}"
+        self.app.call_from_thread(self._apply_result, text)
+
+    def _run_both(self) -> None:
+        from garmin_extract._google_drive import sync_to_sheets, upload_csvs_to_drive
+
+        lines = []
+
+        drive_result = upload_csvs_to_drive()
+        if drive_result["ok"]:
+            names = "  ·  ".join(f["name"] for f in drive_result["files"])
+            lines.append(f"[green]✓[/] Drive: {names}")
+        else:
+            lines.append(f"[red]✗[/] Drive: {drive_result['error']}")
+
+        sheets_result = sync_to_sheets()
+        if sheets_result["ok"]:
+            lines.append(f"[green]✓[/] Sheets updated\n[dim]{sheets_result['sheet_url']}[/]")
+        else:
+            lines.append(f"[red]✗[/] Sheets: {sheets_result['error']}")
+
+        self.app.call_from_thread(self._apply_result, "\n".join(lines))
+
+    def _apply_result(self, text: str) -> None:
+        self._set_status(text)
+        # Refresh last-export timestamp
+        self.run_worker(self._check_auth, thread=True, name="ds-auth-refresh")
+
+    # ── navigation ───────────────────────────────────────────────────────────
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def action_quit(self) -> None:
+        self.app.exit()


### PR DESCRIPTION
## Summary

- Replaces the Phase 5 `StubScreen` with a real `DriveSheetsScreen` backed by a new `_google_drive.py` helper module
- Reuses the existing OAuth token (gmail + drive + sheets scopes already requested by `setup_gmail_auth.py`) — no new auth setup required for users who completed Gmail OAuth
- State (folder ID, sheet ID, last export timestamp) persisted in `.drive_config.json` (gitignored)

**New files:**
- `garmin_extract/_google_drive.py` — `check_auth()`, `upload_csvs_to_drive()`, `sync_to_sheets()`, Drive folder + file helpers
- `garmin_extract/screens/drive_sheets.py` — `DriveSheetsScreen` with `[1]` Drive, `[2]` Sheets, `[3]` Both; auth status + last-export on mount; all API calls in worker threads

**Modified:**
- `automation.py` — swaps `StubScreen` push for `DriveSheetsScreen()`
- `.gitignore` — adds `.drive_config.json`

## Test plan

- [ ] Launch TUI → Automation → Google Drive / Sheets
- [ ] Auth status line shows green (token has drive/sheets scopes)
- [ ] `[1]` Upload to Drive — uploads both CSVs, shows folder link
- [ ] `[2]` Sync to Sheets — creates/updates spreadsheet, shows sheet URL
- [ ] `[3]` Both — runs Drive + Sheets in sequence, shows both results
- [ ] Last export timestamp updates after each successful export
- [ ] Re-entering screen refreshes auth + last-export state
- [ ] Missing CSVs show actionable error ("Run 'Pull Data' first")
- [ ] Token without drive/sheets scopes shows upgrade hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)