### PR TITLE
fix: batch feedback fixes from v1.2.0 real-world testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,12 @@ reports/*.csv
 # Drive/Sheets config (local state — folder ID, sheet ID, last export)
 .drive_config.json
 
+# App config (persisted theme, user preferences)
+.garmin_config.json
+
+# Files downloaded by Chrome / SeleniumBase during browser automation
+downloaded_files/
+
 # Logs
 *.log
 logs/

--- a/garmin_extract/app.py
+++ b/garmin_extract/app.py
@@ -2,9 +2,30 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from textual.app import App
 
 from garmin_extract import __version__
+
+_CONFIG_FILE = Path(__file__).parent.parent / ".garmin_config.json"
+
+
+def _load_app_config() -> dict:
+    if _CONFIG_FILE.exists():
+        try:
+            return json.loads(_CONFIG_FILE.read_text())
+        except Exception:
+            return {}
+    return {}
+
+
+def _save_app_config(cfg: dict) -> None:
+    try:
+        _CONFIG_FILE.write_text(json.dumps(cfg, indent=2))
+    except Exception:
+        pass
 
 
 class GarminExtractApp(App[None]):
@@ -19,6 +40,15 @@ class GarminExtractApp(App[None]):
         self.verbose = verbose
 
     def on_mount(self) -> None:
+        cfg = _load_app_config()
+        if saved_theme := cfg.get("theme"):
+            self.theme = saved_theme
         from garmin_extract.screens.main_menu import MainMenuScreen
 
         self.push_screen(MainMenuScreen())
+
+    def watch_theme(self, theme: str) -> None:
+        """Persist theme selection across restarts."""
+        cfg = _load_app_config()
+        cfg["theme"] = theme
+        _save_app_config(cfg)

--- a/garmin_extract/screens/pull_progress.py
+++ b/garmin_extract/screens/pull_progress.py
@@ -393,17 +393,22 @@ class PullProgressScreen(Screen[None]):
                 ds.done += 1
             else:
                 ds.failed += 1
-            self._overall_done += 1
-            self.query_one("#progress-bar", ProgressBar).advance(1)
 
-            # Day complete when done + failed == total
-            if ds.total > 0 and (ds.done + ds.failed) >= ds.total:
+            # Only advance progress up to the announced total — per-activity
+            # sub-requests emit extra ✓/✗ lines that exceed the day's metric count.
+            tally = ds.done + ds.failed
+            if ds.total == 0 or tally <= ds.total:
+                self._overall_done += 1
+                self.query_one("#progress-bar", ProgressBar).advance(1)
+
+            # Day complete when tally reaches the announced total
+            if ds.total > 0 and tally >= ds.total:
                 ds.status = "done"
 
             self._refresh_day_list()
             self._set_status(
                 f"Day {self._current_day_index + 1} of {self._days}"
-                f"  ·  {ds.done + ds.failed}/{ds.total or '?'} metrics"
+                f"  ·  {min(tally, ds.total) if ds.total else tally}/{ds.total or '?'} metrics"
             )
 
     # ── completion / error ─────────────────────────────────────────────────────
@@ -411,6 +416,16 @@ class PullProgressScreen(Screen[None]):
     def _on_done(self, returncode: int) -> None:
         self._done = True
         log = self.query_one("#log-panel", RichLog)
+
+        # For simple mode (rebuild-only / zip import), the right panel and progress
+        # bar are never updated during the run — complete them now.
+        if self._mode == "simple":
+            panel_text = "[green]✓ Complete[/]" if returncode == 0 else "[red]✗ Failed[/]"
+            self.query_one("#metric-list", Static).update(panel_text)
+            bar = self.query_one("#progress-bar", ProgressBar)
+            bar.total = 1
+            bar.advance(1)
+
         if returncode == 0:
             self._set_status("Complete ✓  —  press  b  to go back")
             log.write("\n[green]Done.[/green]  Press  [bold]b[/bold]  to go back.")
@@ -434,7 +449,8 @@ class PullProgressScreen(Screen[None]):
         lines: list[str] = []
         for ds in self._day_states:
             if ds.status == "done":
-                count = f"({ds.done}/{ds.total})" if ds.total else ""
+                tally = min(ds.done + ds.failed, ds.total) if ds.total else ds.done + ds.failed
+                count = f"({tally}/{ds.total})" if ds.total else ""
                 failed = f"  [red]{ds.failed} failed[/]" if ds.failed else ""
                 lines.append(f"[green]✓[/] {ds.date_str}  [dim]{count}[/]{failed}")
             elif ds.status == "active":

--- a/garmin_extract/screens/setup.py
+++ b/garmin_extract/screens/setup.py
@@ -319,6 +319,20 @@ class PrereqScreen(Screen[None]):
     def on_mount(self) -> None:
         self.run_worker(lambda: self._run_checks(), thread=True, name="prereq-checker")
 
+    def on_screen_resume(self) -> None:
+        """Re-run checks when navigating back from the install screen."""
+        self._states = {k: "pending" for k in self._ITEMS}
+        self._details = {}
+        self._done = False
+        self._can_install = False
+        self.query_one("#prereq-progress", ProgressBar).update(progress=0)
+        self.query_one("#prereq-progress", ProgressBar).display = True
+        self.query_one("#prereq-list", Static).update(self._render_list())
+        self.query_one("#prereq-status", Static).update("Running checks…")
+        self.run_worker(
+            lambda: self._run_checks(), thread=True, name="prereq-checker", exclusive=True
+        )
+
     def _run_checks(self) -> None:
         log = self.query_one("#prereq-log", RichLog)
         checks = [
@@ -345,6 +359,7 @@ class PrereqScreen(Screen[None]):
             self.app.call_from_thread(log.write, f"{icon}  {name}:  {detail}")
 
         self._done = True
+        self.app.call_from_thread(self._hide_progress_bar)
         if not failed:
             self.app.call_from_thread(
                 self.query_one("#prereq-status", Static).update,
@@ -370,6 +385,12 @@ class PrereqScreen(Screen[None]):
                     "\n[yellow]Please install the missing items manually,"
                     " then re-run this check.[/yellow]",
                 )
+
+    def _hide_progress_bar(self) -> None:
+        try:
+            self.query_one("#prereq-progress", ProgressBar).display = False
+        except Exception:
+            pass
 
     def _show_install_binding(self) -> None:
         try:


### PR DESCRIPTION
## Summary

Five bugs caught during first real-world use of v1.2.0, fixed in a single batch.

- **B1 — PrereqScreen progress bar lingers at 100%**: Hidden via `display = False` after checks complete
- **B2 — No re-check after Chrome install**: Added `on_screen_resume` to `PrereqScreen` that resets state and re-runs all checks when navigating back from the install screen
- **B3 — Day mode counter shows 36/28**: Per-activity sub-requests emit extra `✓/✗` lines beyond the announced metric count. Progress bar and tally now capped at the announced total; display shows `done+failed/total` (not `done/total`)
- **B4 — Rebuild CSV stuck at "Starting..." / 0%**: `simple` mode (rebuild-only) never updated the right panel or progress bar. `_on_done` now sets the panel to `✓ Complete` / `✗ Failed` and advances the bar to 100%
- **B5 — Theme resets on restart**: `watch_theme` saves selection to `.garmin_config.json`; `on_mount` restores it on next launch

Also adds `downloaded_files/` and `.garmin_config.json` to `.gitignore`.

## Test plan

- [ ] PrereqScreen: progress bar disappears after checks finish
- [ ] PrereqScreen: re-entering screen after Chrome install re-runs all checks automatically
- [ ] Day mode pull: counter stays at or below announced metric count (e.g. 28/28, not 36/28)
- [ ] Rebuild CSV: right panel updates to "✓ Complete" and bar fills to 100% on finish
- [ ] Change theme via `^p` palette → close app → reopen → theme is restored
- [ ] `downloaded_files/` no longer shows as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)