### PR TITLE
feat: arrow/j/k vim navigation across all menu screens (#19)

### DIFF
--- a/garmin_extract/screens/automation.py
+++ b/garmin_extract/screens/automation.py
@@ -16,21 +16,31 @@ GMAIL_TOKEN_FILE = ROOT / ".google_token.json"
 PULL_SCRIPT = ROOT / "scripts" / "pull-garmin.sh"
 _CRON_MARKER = "# garmin-extract"
 
-_MENU = """\
+_W = 53
+_ITEMS = [
+    ("1", "Gmail MFA", "View automation status"),
+    ("2", "Scheduled Pulls", "Set up automatic daily data pull"),
+    ("3", "Google Drive / Sheets", "Export to Google services"),
+]
+_EMPTY_ROW = "  │" + " " * _W + "│"
 
-  ┌─────────────────────────────────────────────────────┐
-  │                                                     │
-  │   [1]  Gmail MFA                                    │
-  │        View automation status                       │
-  │                                                     │
-  │   [2]  Scheduled Pulls                              │
-  │        Set up automatic daily data pull             │
-  │                                                     │
-  │   [3]  Google Drive / Sheets                        │
-  │        Export to Google services                    │
-  │                                                     │
-  └─────────────────────────────────────────────────────┘\
-"""
+
+def _build_menu(cursor: int = 0) -> str:
+    top = "  ┌" + "─" * _W + "┐"
+    bottom = "  └" + "─" * _W + "┘"
+    rows = ["\n" + top, _EMPTY_ROW]
+    for i, (key, label, hint) in enumerate(_ITEMS):
+        sel = i == cursor
+        cur = "❯" if sel else " "
+        lbl = f"[bold]{label}[/]" if sel else label
+        h = f"[bold]{hint}[/]" if sel else hint
+        lbl_pad = " " * (_W - 8 - len(label))
+        hint_pad = " " * (_W - 8 - len(hint))
+        rows.append(f"  │ {cur} [bold cyan][{key}][/]  {lbl}{lbl_pad}│")
+        rows.append(f"  │        [dim]{h}[/]{hint_pad}│")
+        rows.append(_EMPTY_ROW)
+    rows.append(bottom)
+    return "\n".join(rows)
 
 
 # ── cron helpers ──────────────────────────────────────────────────────────────
@@ -137,10 +147,17 @@ def _check_gmail_automation() -> tuple[str, str]:
 class AutomationScreen(Screen[None]):
     """Automation landing — Gmail MFA status, cron schedule, Drive/Sheets."""
 
+    _ITEM_COUNT = 3
+
     BINDINGS = [
-        Binding("1", "go_gmail", "Gmail MFA", show=False),
-        Binding("2", "go_cron", "Cron Schedule", show=False),
-        Binding("3", "go_sheets", "Drive/Sheets", show=False),
+        Binding("1", "go_gmail", show=False),
+        Binding("2", "go_cron", show=False),
+        Binding("3", "go_sheets", show=False),
+        Binding("up", "cursor_up", show=False),
+        Binding("k", "cursor_up", show=False),
+        Binding("down", "cursor_down", show=False),
+        Binding("j", "cursor_down", show=False),
+        Binding("enter", "cursor_select", show=False),
         Binding("b", "back", "Back", show=True),
         Binding("q", "quit", "Quit", show=True),
     ]
@@ -174,17 +191,42 @@ class AutomationScreen(Screen[None]):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
         yield Static("Automation", id="auto-header")
-        yield Static(_MENU, id="auto-options")
-        yield Static("Press  1  2  3  to select  ·  b  to go back", id="auto-hint")
+        yield Static(_build_menu(0), id="auto-options")
+        yield Static(
+            "↑↓  j/k  navigate  ·  enter  select  ·  1–3  direct  ·  b  back",
+            id="auto-hint",
+        )
         yield Footer()
 
+    def on_mount(self) -> None:
+        self._cursor = 0
+
+    def _refresh_menu(self) -> None:
+        self.query_one("#auto-options", Static).update(_build_menu(self._cursor))
+
+    def action_cursor_up(self) -> None:
+        if self._cursor > 0:
+            self._cursor -= 1
+            self._refresh_menu()
+
+    def action_cursor_down(self) -> None:
+        if self._cursor < self._ITEM_COUNT - 1:
+            self._cursor += 1
+            self._refresh_menu()
+
+    def action_cursor_select(self) -> None:
+        [self.action_go_gmail, self.action_go_cron, self.action_go_sheets][self._cursor]()
+
     def action_go_gmail(self) -> None:
+        self._cursor = 0
         self.app.push_screen(GmailMfaScreen())
 
     def action_go_cron(self) -> None:
+        self._cursor = 1
         self.app.push_screen(CronScreen())
 
     def action_go_sheets(self) -> None:
+        self._cursor = 2
         from garmin_extract.screens.drive_sheets import DriveSheetsScreen
 
         self.app.push_screen(DriveSheetsScreen())

--- a/garmin_extract/screens/data_pull.py
+++ b/garmin_extract/screens/data_pull.py
@@ -27,6 +27,8 @@ def _yesterday() -> str:
 class DataPullScreen(Screen[None]):
     """Submenu for pulling data and rebuilding reports."""
 
+    _ITEM_COUNT = 7
+
     BINDINGS = [
         Binding("1", "pull_yesterday", show=False),
         Binding("2", "pull_7", show=False),
@@ -35,6 +37,11 @@ class DataPullScreen(Screen[None]):
         Binding("5", "pull_history", show=False),
         Binding("6", "import_zip", show=False),
         Binding("7", "rebuild_csvs", show=False),
+        Binding("up", "cursor_up", show=False),
+        Binding("k", "cursor_up", show=False),
+        Binding("down", "cursor_down", show=False),
+        Binding("j", "cursor_down", show=False),
+        Binding("enter", "cursor_select", show=False),
         Binding("b", "back", "Back", show=True),
         Binding("q", "quit", "Quit", show=True),
     ]
@@ -70,36 +77,73 @@ class DataPullScreen(Screen[None]):
     }
     """
 
+    def _item(self, n: int, key: str, label: str, hint: str = "") -> str:
+        """Render one menu item with cursor indicator if selected."""
+        sel = (n - 1) == self._cursor
+        pre = "❯ " if sel else "  "
+        lbl = f"[bold]{label}[/]" if sel else label
+        h = f"  [dim]{hint}[/]" if hint else ""
+        return f"{pre}[bold cyan][{key}][/]  {lbl}{h}"
+
     def _build_menu(self) -> str:
         yest = _yesterday()
         r7 = _date_range_label(7)
         r30 = _date_range_label(30)
+        _ = self._item
         return (
             f"\n"
             f"  [bold dim]RECENT[/]\n  {'─' * 51}\n"
-            f"  [bold cyan][1][/]  Yesterday              [dim]{yest}[/]\n"
-            f"  [bold cyan][2][/]  Last 7 days            [dim]{r7}[/]\n"
-            f"  [bold cyan][3][/]  Last 30 days           [dim]{r30}[/]\n"
+            f"{_(1, '1', 'Yesterday', yest)}\n"
+            f"{_(2, '2', 'Last 7 days', r7)}\n"
+            f"{_(3, '3', 'Last 30 days', r30)}\n"
             f"\n"
             f"  [bold dim]CUSTOM[/]\n  {'─' * 51}\n"
-            f"  [bold cyan][4][/]  Specific date or range\n"
-            f"  [bold cyan][5][/]  Full history  [dim](from a date you choose)[/]\n"
+            f"{_(4, '4', 'Specific date or range')}\n"
+            f"{_(5, '5', 'Full history', '(from a date you choose)')}\n"
             f"\n"
             f"  [bold dim]IMPORT[/]\n  {'─' * 51}\n"
-            f"  [bold cyan][6][/]  Import from Garmin bulk export  [dim](.zip)[/]\n"
+            f"{_(6, '6', 'Import from Garmin bulk export', '.zip')}\n"
             f"\n"
             f"  [bold dim]REPORTS[/]\n  {'─' * 51}\n"
-            f"  [bold cyan][7][/]  Rebuild CSV reports  [dim](from existing data)[/]\n"
+            f"{_(7, '7', 'Rebuild CSV reports', 'from existing data')}\n"
         )
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
         yield Static(self._build_menu(), id="pull-menu")
         yield Static(
-            "Press a number to select  ·  b  back  ·  q  quit",
+            "↑↓  j/k  navigate  ·  enter  select  ·  1–7  direct  ·  b  back",
             id="pull-hint",
         )
         yield Footer()
+
+    def on_mount(self) -> None:
+        self._cursor = 0
+
+    def _refresh_menu(self) -> None:
+        self.query_one("#pull-menu", Static).update(self._build_menu())
+
+    def action_cursor_up(self) -> None:
+        if self._cursor > 0:
+            self._cursor -= 1
+            self._refresh_menu()
+
+    def action_cursor_down(self) -> None:
+        if self._cursor < self._ITEM_COUNT - 1:
+            self._cursor += 1
+            self._refresh_menu()
+
+    def action_cursor_select(self) -> None:
+        _actions = [
+            self.action_pull_yesterday,
+            self.action_pull_7,
+            self.action_pull_30,
+            self.action_pull_custom,
+            self.action_pull_history,
+            self.action_import_zip,
+            self.action_rebuild_csvs,
+        ]
+        _actions[self._cursor]()
 
     def _push_progress(
         self,
@@ -122,27 +166,34 @@ class DataPullScreen(Screen[None]):
         )
 
     def action_pull_yesterday(self) -> None:
+        self._cursor = 0
         yest = _yesterday()
         self._push_progress(yest, 1, f"Yesterday  ({yest})")
 
     def action_pull_7(self) -> None:
+        self._cursor = 1
         start = (date.today() - timedelta(days=7)).isoformat()
         self._push_progress(start, 7, f"Last 7 days  ({_date_range_label(7)})")
 
     def action_pull_30(self) -> None:
+        self._cursor = 2
         start = (date.today() - timedelta(days=30)).isoformat()
         self._push_progress(start, 30, f"Last 30 days  ({_date_range_label(30)})")
 
     def action_pull_custom(self) -> None:
+        self._cursor = 3
         self.app.push_screen(CustomDateScreen())
 
     def action_pull_history(self) -> None:
+        self._cursor = 4
         self.app.push_screen(FullHistoryScreen())
 
     def action_import_zip(self) -> None:
+        self._cursor = 5
         self.app.push_screen(ImportZipScreen())
 
     def action_rebuild_csvs(self) -> None:
+        self._cursor = 6
         self._push_progress("", 0, "Rebuilding CSV reports", rebuild_only=True)
 
     def action_back(self) -> None:

--- a/garmin_extract/screens/drive_sheets.py
+++ b/garmin_extract/screens/drive_sheets.py
@@ -7,30 +7,47 @@ from textual.binding import Binding
 from textual.screen import Screen
 from textual.widgets import Footer, Header, Static
 
-_MENU = """\
+_W = 53
+_ITEMS = [
+    ("1", "Upload CSVs to Drive", "Upload garmin_daily.csv + activities.csv"),
+    ("2", "Sync to Google Sheets", "Create / update a Garmin Data spreadsheet"),
+    ("3", "Both (Drive + Sheets)", "Upload CSVs and sync spreadsheet"),
+]
+_EMPTY_ROW = "  │" + " " * _W + "│"
 
-  ┌─────────────────────────────────────────────────────┐
-  │                                                     │
-  │   [1]  Upload CSVs to Drive                         │
-  │        Upload garmin_daily.csv + activities.csv     │
-  │                                                     │
-  │   [2]  Sync to Google Sheets                        │
-  │        Create / update a Garmin Data spreadsheet    │
-  │                                                     │
-  │   [3]  Both (Drive + Sheets)                        │
-  │        Upload CSVs and sync spreadsheet             │
-  │                                                     │
-  └─────────────────────────────────────────────────────┘\
-"""
+
+def _build_menu(cursor: int = 0) -> str:
+    top = "  ┌" + "─" * _W + "┐"
+    bottom = "  └" + "─" * _W + "┘"
+    rows = ["\n" + top, _EMPTY_ROW]
+    for i, (key, label, hint) in enumerate(_ITEMS):
+        sel = i == cursor
+        cur = "❯" if sel else " "
+        lbl = f"[bold]{label}[/]" if sel else label
+        h = f"[bold]{hint}[/]" if sel else hint
+        lbl_pad = " " * (_W - 8 - len(label))
+        hint_pad = " " * (_W - 8 - len(hint))
+        rows.append(f"  │ {cur} [bold cyan][{key}][/]  {lbl}{lbl_pad}│")
+        rows.append(f"  │        [dim]{h}[/]{hint_pad}│")
+        rows.append(_EMPTY_ROW)
+    rows.append(bottom)
+    return "\n".join(rows)
 
 
 class DriveSheetsScreen(Screen[None]):
     """Google Drive / Sheets export landing screen."""
 
+    _ITEM_COUNT = 3
+
     BINDINGS = [
-        Binding("1", "do_drive", "Upload to Drive", show=False),
-        Binding("2", "do_sheets", "Sync to Sheets", show=False),
-        Binding("3", "do_both", "Both", show=False),
+        Binding("1", "do_drive", show=False),
+        Binding("2", "do_sheets", show=False),
+        Binding("3", "do_both", show=False),
+        Binding("up", "cursor_up", show=False),
+        Binding("k", "cursor_up", show=False),
+        Binding("down", "cursor_down", show=False),
+        Binding("j", "cursor_down", show=False),
+        Binding("enter", "cursor_select", show=False),
         Binding("b", "back", "Back", show=True),
         Binding("q", "quit", "Quit", show=True),
     ]
@@ -81,16 +98,36 @@ class DriveSheetsScreen(Screen[None]):
         yield Static("Google Drive / Sheets", id="ds-header")
         yield Static("Checking authorization…", id="ds-auth")
         yield Static("", id="ds-last")
-        yield Static(_MENU, id="ds-menu")
-        yield Static("Press  1  2  3  to select  ·  b  to go back", id="ds-hint")
+        yield Static(_build_menu(0), id="ds-menu")
+        yield Static(
+            "↑↓  j/k  navigate  ·  enter  select  ·  1–3  direct  ·  b  back",
+            id="ds-hint",
+        )
         yield Static("", id="ds-status")
         yield Footer()
 
     def on_mount(self) -> None:
+        self._cursor = 0
         self.run_worker(self._check_auth, thread=True, name="ds-auth-check")
 
     def on_screen_resume(self) -> None:
         self.run_worker(self._check_auth, thread=True, name="ds-auth-check")
+
+    def _refresh_menu(self) -> None:
+        self.query_one("#ds-menu", Static).update(_build_menu(self._cursor))
+
+    def action_cursor_up(self) -> None:
+        if self._cursor > 0:
+            self._cursor -= 1
+            self._refresh_menu()
+
+    def action_cursor_down(self) -> None:
+        if self._cursor < self._ITEM_COUNT - 1:
+            self._cursor += 1
+            self._refresh_menu()
+
+    def action_cursor_select(self) -> None:
+        [self.action_do_drive, self.action_do_sheets, self.action_do_both][self._cursor]()
 
     # ── auth status ──────────────────────────────────────────────────────────
 
@@ -130,14 +167,20 @@ class DriveSheetsScreen(Screen[None]):
         self.query_one("#ds-status", Static).update(text)
 
     def action_do_drive(self) -> None:
+        self._cursor = 0
+        self._refresh_menu()
         self._set_status("[dim]Uploading CSVs to Drive…[/]")
         self.run_worker(self._run_drive, thread=True, exclusive=True, name="ds-drive")
 
     def action_do_sheets(self) -> None:
+        self._cursor = 1
+        self._refresh_menu()
         self._set_status("[dim]Syncing to Google Sheets…[/]")
         self.run_worker(self._run_sheets, thread=True, exclusive=True, name="ds-sheets")
 
     def action_do_both(self) -> None:
+        self._cursor = 2
+        self._refresh_menu()
         self._set_status("[dim]Uploading CSVs and syncing Sheets…[/]")
         self.run_worker(self._run_both, thread=True, exclusive=True, name="ds-both")
 

--- a/garmin_extract/screens/main_menu.py
+++ b/garmin_extract/screens/main_menu.py
@@ -9,35 +9,50 @@ from textual.widgets import Footer, Header, Static
 
 from garmin_extract import __version__
 
-_MENU = f"""\
+_TITLE = f"""\
   garmin-extract  v{__version__}
   Automated Garmin Connect data pipeline\
 """
 
-_OPTIONS = """\
+_W = 53  # inner box width
+_EMPTY_ROW = "  │" + " " * _W + "│"
+_ITEMS = [
+    ("1", "Initial Setup", "Configure credentials and prerequisites"),
+    ("2", "Pull Data", "Download your Garmin health metrics"),
+    ("3", "Automation", "Gmail MFA, scheduled pulls, Drive / Sheets"),
+]
 
-  ┌─────────────────────────────────────────────────────┐
-  │                                                     │
-  │   [1]  Initial Setup                                │
-  │        Configure credentials and prerequisites      │
-  │                                                     │
-  │   [2]  Pull Data                                    │
-  │        Download your Garmin health metrics          │
-  │                                                     │
-  │   [3]  Automation                                   │
-  │        Gmail MFA, scheduled pulls, Drive / Sheets   │
-  │                                                     │
-  └─────────────────────────────────────────────────────┘\
-"""
+
+def _build_menu(cursor: int) -> str:
+    top = "  ┌" + "─" * _W + "┐"
+    bottom = "  └" + "─" * _W + "┘"
+    rows = ["\n" + top, _EMPTY_ROW]
+    for i, (key, label, hint) in enumerate(_ITEMS):
+        sel = i == cursor
+        cur = "❯" if sel else " "
+        lbl = f"[bold]{label}[/]" if sel else label
+        h = f"[bold]{hint}[/]" if sel else hint
+        lbl_pad = " " * (_W - 8 - len(label))
+        hint_pad = " " * (_W - 8 - len(hint))
+        rows.append(f"  │ {cur} [bold cyan][{key}][/]  {lbl}{lbl_pad}│")
+        rows.append(f"  │        [dim]{h}[/]{hint_pad}│")
+        rows.append(_EMPTY_ROW)
+    rows.append(bottom)
+    return "\n".join(rows)
 
 
 class MainMenuScreen(Screen[None]):
     """Landing screen — routes to the three main sections."""
 
     BINDINGS = [
-        Binding("1", "go_setup", "Initial Setup", show=False),
-        Binding("2", "go_pull", "Pull Data", show=False),
-        Binding("3", "go_automation", "Automation", show=False),
+        Binding("1", "go_setup", show=False),
+        Binding("2", "go_pull", show=False),
+        Binding("3", "go_automation", show=False),
+        Binding("up", "cursor_up", show=False),
+        Binding("k", "cursor_up", show=False),
+        Binding("down", "cursor_down", show=False),
+        Binding("j", "cursor_down", show=False),
+        Binding("enter", "cursor_select", show=False),
         Binding("q", "quit", "Quit", show=True),
     ]
 
@@ -69,22 +84,47 @@ class MainMenuScreen(Screen[None]):
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
-        yield Static(_MENU, id="menu-header")
-        yield Static(_OPTIONS, id="menu-options")
-        yield Static("Press  1  2  3  to select  ·  q  to quit", id="menu-hint")
+        yield Static(_TITLE, id="menu-header")
+        yield Static(_build_menu(0), id="menu-options")
+        yield Static(
+            "↑↓  j/k  navigate  ·  enter  select  ·  1–3  direct  ·  q  quit",
+            id="menu-hint",
+        )
         yield Footer()
 
+    def on_mount(self) -> None:
+        self._cursor = 0
+
+    def _refresh_menu(self) -> None:
+        self.query_one("#menu-options", Static).update(_build_menu(self._cursor))
+
+    def action_cursor_up(self) -> None:
+        if self._cursor > 0:
+            self._cursor -= 1
+            self._refresh_menu()
+
+    def action_cursor_down(self) -> None:
+        if self._cursor < 2:
+            self._cursor += 1
+            self._refresh_menu()
+
+    def action_cursor_select(self) -> None:
+        [self.action_go_setup, self.action_go_pull, self.action_go_automation][self._cursor]()
+
     def action_go_setup(self) -> None:
+        self._cursor = 0
         from garmin_extract.screens.setup import SetupScreen
 
         self.app.push_screen(SetupScreen())
 
     def action_go_pull(self) -> None:
+        self._cursor = 1
         from garmin_extract.screens.data_pull import DataPullScreen
 
         self.app.push_screen(DataPullScreen())
 
     def action_go_automation(self) -> None:
+        self._cursor = 2
         from garmin_extract.screens.automation import AutomationScreen
 
         self.app.push_screen(AutomationScreen())

--- a/garmin_extract/screens/setup.py
+++ b/garmin_extract/screens/setup.py
@@ -99,10 +99,17 @@ def _status_tag(ok: bool, text: str) -> str:
 class SetupScreen(Screen[None]):
     """Landing screen for Initial Setup — shows live status for all three areas."""
 
+    _ITEM_COUNT = 3
+
     BINDINGS = [
         Binding("1", "go_prereqs", show=False),
         Binding("2", "go_credentials", show=False),
         Binding("3", "go_gmail", show=False),
+        Binding("up", "cursor_up", show=False),
+        Binding("k", "cursor_up", show=False),
+        Binding("down", "cursor_down", show=False),
+        Binding("j", "cursor_down", show=False),
+        Binding("enter", "cursor_select", show=False),
         Binding("b", "back", "Back", show=True),
         Binding("q", "quit", "Quit", show=True),
     ]
@@ -130,12 +137,19 @@ class SetupScreen(Screen[None]):
         yield Header(show_clock=True)
         yield Static(self._build_menu(), id="setup-menu")
         yield Static(
-            "Press a number to select  ·  b  back  ·  q  quit",
+            "↑↓  j/k  navigate  ·  enter  select  ·  1–3  direct  ·  b  back",
             id="setup-hint",
         )
         yield Footer()
 
     def on_mount(self) -> None:
+        self._cursor = 0
+        self._prereq_ok = False
+        self._prereq_status = "[dim]checking…[/]"
+        self._creds_ok = False
+        self._creds_str = "[dim]checking…[/]"
+        self._gmail_ok = False
+        self._gmail_str = "[dim]checking…[/]"
         self._refresh_status()
 
     def on_screen_resume(self) -> None:
@@ -187,8 +201,24 @@ class SetupScreen(Screen[None]):
         gmail_ok: bool,
         gmail_str: str,
     ) -> None:
+        self._prereq_ok = prereq_ok
+        self._prereq_status = prereq_status
+        self._creds_ok = creds_ok
+        self._creds_str = creds_str
+        self._gmail_ok = gmail_ok
+        self._gmail_str = gmail_str
+        self._redraw_menu()
+
+    def _redraw_menu(self) -> None:
         self.query_one("#setup-menu", Static).update(
-            self._build_menu(prereq_ok, prereq_status, creds_ok, creds_str, gmail_ok, gmail_str)
+            self._build_menu(
+                self._prereq_ok,
+                self._prereq_status,
+                self._creds_ok,
+                self._creds_str,
+                self._gmail_ok,
+                self._gmail_str,
+            )
         )
 
     def _build_menu(
@@ -200,31 +230,55 @@ class SetupScreen(Screen[None]):
         gmail_ok: bool = False,
         gmail_str: str = "[dim]checking…[/]",
     ) -> str:
+        cursor = getattr(self, "_cursor", 0)
         p_icon = "[green]✓[/]" if prereq_ok else "[yellow]○[/]"
         c_icon = "[green]✓[/]" if creds_ok else "[yellow]○[/]"
         g_icon = "[green]✓[/]" if gmail_ok else "[dim]○[/]"
+
+        def _pre(idx: int) -> str:
+            return "❯ " if cursor == idx else "  "
+
+        def _lbl(text: str, idx: int) -> str:
+            return f"[bold]{text}[/]" if cursor == idx else text
+
         return (
             f"\n"
             f"  [bold dim]PREREQUISITES[/]\n  {'─' * 51}\n"
-            f"  [bold cyan][1][/]  Check & Install\n"
+            f"{_pre(0)}[bold cyan][1][/]  {_lbl('Check & Install', 0)}\n"
             f"       {p_icon}  {prereq_status}\n"
             f"\n"
             f"  [bold dim]CREDENTIALS[/]\n  {'─' * 51}\n"
-            f"  [bold cyan][2][/]  Garmin Connect\n"
+            f"{_pre(1)}[bold cyan][2][/]  {_lbl('Garmin Connect', 1)}\n"
             f"       {c_icon}  [dim]{creds_str}[/]\n"
             f"\n"
             f"  [bold dim]AUTOMATION[/]  [dim](optional)[/]\n  {'─' * 51}\n"
-            f"  [bold cyan][3][/]  Gmail MFA\n"
+            f"{_pre(2)}[bold cyan][3][/]  {_lbl('Gmail MFA', 2)}\n"
             f"       {g_icon}  [dim]{gmail_str}[/]\n"
         )
 
+    def action_cursor_up(self) -> None:
+        if self._cursor > 0:
+            self._cursor -= 1
+            self._redraw_menu()
+
+    def action_cursor_down(self) -> None:
+        if self._cursor < self._ITEM_COUNT - 1:
+            self._cursor += 1
+            self._redraw_menu()
+
+    def action_cursor_select(self) -> None:
+        [self.action_go_prereqs, self.action_go_credentials, self.action_go_gmail][self._cursor]()
+
     def action_go_prereqs(self) -> None:
+        self._cursor = 0
         self.app.push_screen(PrereqScreen())
 
     def action_go_credentials(self) -> None:
+        self._cursor = 1
         self.app.push_screen(CredentialsScreen())
 
     def action_go_gmail(self) -> None:
+        self._cursor = 2
         self.app.push_screen(GmailSetupScreen())
 
     def action_back(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.1.0"
+version = "1.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary
- All 5 menu screens now support `↑↓`, `j/k`, `enter`, and `1–N` direct key navigation
- `main_menu.py` and `data_pull.py`: cursor-aware `_build_menu(cursor)` with `❯` indicator
- `setup.py` (SetupScreen): cursor + cached status params so nav redraws without re-running async checks
- `automation.py` and `drive_sheets.py`: replaced static `_MENU` constants with `_build_menu(cursor)` using same `_W=53` box-drawing pattern
- All number-key direct actions sync `self._cursor` for visual consistency
- Updated hint text on all screens: `↑↓  j/k  navigate  ·  enter  select  ·  1–N  direct  ·  b  back`
- Also includes `uv.lock` version sync (1.1.0 → 1.2.1) missed from prior release commit

## Test plan
- [ ] Arrow keys and j/k move cursor highlight on all 5 menu screens
- [ ] Enter selects highlighted item
- [ ] Direct number keys still work and sync cursor position
- [ ] Navigation wraps at bounds (no wrap-around — stops at first/last)

🤖 Generated with [Claude Code](https://claude.com/claude-code)