### PR TITLE
feat: keyring-first credential storage with .env fallback and runtime entry (#21)

### DIFF
--- a/garmin_extract/_credentials.py
+++ b/garmin_extract/_credentials.py
@@ -1,0 +1,127 @@
+"""Credential storage — keyring-first, .env fallback, runtime as last resort."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SERVICE = "garmin-extract"
+_EMAIL_KEY = "email"
+_PASSWORD_KEY = "password"
+_PROBE_KEY = "_probe"
+ROOT = Path(__file__).parent.parent
+ENV_FILE = ROOT / ".env"
+
+
+def detect_keyring() -> tuple[bool, str]:
+    """
+    Returns (available, detail).
+    Performs a write/read/delete smoke-test to confirm the backend actually works.
+    """
+    try:
+        import keyring  # noqa: PLC0415
+
+        backend = keyring.get_keyring()
+        name = type(backend).__name__
+
+        # Backends that can never store a secret
+        if any(x in name for x in ("Fail", "Null", "PlainText")):
+            return False, f"No secure backend ({name})"
+
+        # Smoke-test: write, read, delete
+        keyring.set_password(_SERVICE, _PROBE_KEY, "1")
+        val = keyring.get_password(_SERVICE, _PROBE_KEY)
+        try:
+            keyring.delete_password(_SERVICE, _PROBE_KEY)
+        except Exception:
+            pass
+        if val == "1":
+            return True, name
+        return False, "Keyring probe failed"
+
+    except ImportError:
+        return False, "keyring package not installed"
+    except Exception as exc:
+        return False, str(exc)
+
+
+def load_credentials() -> tuple[str, str]:
+    """
+    Returns (email, password).  Either may be empty string.
+    Priority: keyring → .env → ('', '').
+    """
+    try:
+        import keyring  # noqa: PLC0415
+
+        email = keyring.get_password(_SERVICE, _EMAIL_KEY) or ""
+        password = keyring.get_password(_SERVICE, _PASSWORD_KEY) or ""
+        if email or password:
+            return email, password
+    except Exception:
+        pass
+
+    return _load_from_env()
+
+
+def save_to_keyring(email: str, password: str) -> tuple[bool, str]:
+    """Save credentials to OS keyring.  Returns (ok, detail)."""
+    try:
+        import keyring  # noqa: PLC0415
+
+        keyring.set_password(_SERVICE, _EMAIL_KEY, email)
+        keyring.set_password(_SERVICE, _PASSWORD_KEY, password)
+        return True, "Saved to keyring"
+    except Exception as exc:
+        return False, str(exc)
+
+
+def save_to_env(email: str, password: str) -> None:
+    """Write credentials to .env (plaintext)."""
+    lines = [
+        "# Garmin Connect credentials",
+        f"GARMIN_EMAIL={email}",
+        f"GARMIN_PASSWORD={password}",
+    ]
+    ENV_FILE.write_text("\n".join(lines) + "\n")
+
+
+def check_credentials() -> tuple[bool, str]:
+    """
+    Returns (ok, detail) for status display in SetupScreen.
+    Shows where creds came from.
+    """
+    try:
+        import keyring  # noqa: PLC0415
+
+        email = keyring.get_password(_SERVICE, _EMAIL_KEY) or ""
+        password = keyring.get_password(_SERVICE, _PASSWORD_KEY) or ""
+        if email and password:
+            return True, f"{email}  [dim](keyring)[/]"
+        if email:
+            return False, f"{email}  [dim](no password in keyring)[/]"
+    except Exception:
+        pass
+
+    email, password = _load_from_env()
+    if email and password:
+        return True, f"{email}  [dim](.env)[/]"
+    if email:
+        return False, f"{email}  [dim](no password in .env)[/]"
+
+    return False, "Not configured"
+
+
+def _load_from_env() -> tuple[str, str]:
+    email = ""
+    password = ""
+    if ENV_FILE.exists():
+        for line in ENV_FILE.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            k, v = k.strip(), v.strip()
+            if k == "GARMIN_EMAIL":
+                email = v
+            elif k == "GARMIN_PASSWORD":
+                password = v
+    return email, password

--- a/garmin_extract/screens/pull_progress.py
+++ b/garmin_extract/screens/pull_progress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -75,6 +76,72 @@ class _MfaModal(ModalScreen[None]):
             return
         MFA_FILE.write_text(code + "\n")
         self.dismiss()
+
+
+# ── runtime credentials modal ─────────────────────────────────────────────────
+
+
+class _RuntimeCredsModal(ModalScreen[tuple[str, str] | None]):
+    """Prompt for email + password when no credentials are saved anywhere."""
+
+    BINDINGS = [Binding("escape", "dismiss", "Cancel", show=True)]
+
+    CSS = """
+    _RuntimeCredsModal {
+        align: center middle;
+    }
+
+    #rc-box {
+        width: 58;
+        height: auto;
+        border: round $primary;
+        padding: 1 2;
+    }
+
+    #rc-title {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #rc-hint {
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    #rc-error {
+        color: $error;
+        height: 1;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with Static(id="rc-box"):
+            yield Static("Enter Garmin Connect Credentials", id="rc-title")
+            yield Static(
+                "No saved credentials found.  These will not be stored.",
+                id="rc-hint",
+            )
+            yield Input(placeholder="Email", id="rc-email")
+            yield Input(placeholder="Password", password=True, id="rc-password")
+            yield Static("", id="rc-error")
+
+    def on_mount(self) -> None:
+        self.query_one("#rc-email", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "rc-email":
+            self.query_one("#rc-password", Input).focus()
+            return
+        email = self.query_one("#rc-email", Input).value.strip()
+        password = self.query_one("#rc-password", Input).value.strip()
+        if not email:
+            self.query_one("#rc-error", Static).update("Email is required.")
+            self.query_one("#rc-email", Input).focus()
+            return
+        if not password:
+            self.query_one("#rc-error", Static).update("Password is required.")
+            return
+        self.dismiss((email, password))
 
 
 # ── day state (multi-day mode) ────────────────────────────────────────────────
@@ -175,6 +242,8 @@ class PullProgressScreen(Screen[None]):
 
         self._done = False
         self._mfa_shown = False
+        self._email = ""
+        self._password = ""
 
         # Determine display mode
         if days > 1:
@@ -213,6 +282,30 @@ class PullProgressScreen(Screen[None]):
         yield Footer()
 
     def on_mount(self) -> None:
+        # Rebuild/import don't need Garmin credentials
+        if self._rebuild_only or self._zip_path:
+            self._start_pull()
+            return
+
+        from garmin_extract._credentials import load_credentials
+
+        email, password = load_credentials()
+        if password:
+            self._email = email
+            self._password = password
+            self._start_pull()
+        else:
+            self.app.push_screen(_RuntimeCredsModal(), self._on_runtime_creds)
+
+    def _on_runtime_creds(self, creds: tuple[str, str] | None) -> None:
+        if creds is None:
+            # User cancelled — go back
+            self.app.pop_screen()
+            return
+        self._email, self._password = creds
+        self._start_pull()
+
+    def _start_pull(self) -> None:
         cmd = self._build_cmd()
         self.run_worker(lambda: self._do_pull(cmd), thread=True, name="puller")
 
@@ -266,6 +359,14 @@ class PullProgressScreen(Screen[None]):
     # ── worker (thread) ────────────────────────────────────────────────────────
 
     def _do_pull(self, cmd: list[str]) -> None:
+        # Build subprocess env — inject credentials so keyring/runtime creds
+        # reach garmin.py even though it calls load_dotenv() internally.
+        env = os.environ.copy()
+        if self._email:
+            env["GARMIN_EMAIL"] = self._email
+        if self._password:
+            env["GARMIN_PASSWORD"] = self._password
+
         try:
             proc = subprocess.Popen(
                 cmd,
@@ -274,6 +375,7 @@ class PullProgressScreen(Screen[None]):
                 stdin=subprocess.DEVNULL,
                 text=True,
                 cwd=str(ROOT),
+                env=env,
             )
             assert proc.stdout is not None
             for raw_line in iter(proc.stdout.readline, ""):

--- a/garmin_extract/screens/setup.py
+++ b/garmin_extract/screens/setup.py
@@ -69,14 +69,9 @@ def _save_env(vals: dict[str, str]) -> None:
 
 
 def _check_credentials() -> tuple[bool, str]:
-    env = _load_env()
-    email = env.get("GARMIN_EMAIL", "")
-    has_pass = bool(env.get("GARMIN_PASSWORD", ""))
-    if email and has_pass:
-        return True, email
-    if email:
-        return False, f"{email}  (no password)"
-    return False, "Not configured"
+    from garmin_extract._credentials import check_credentials
+
+    return check_credentials()
 
 
 def _check_gmail() -> tuple[bool, str]:
@@ -613,7 +608,7 @@ class CredentialsScreen(Screen[None]):
     }
 
     #creds-box {
-        width: 58;
+        width: 62;
         height: auto;
         border: round $primary;
         padding: 1 2;
@@ -624,9 +619,22 @@ class CredentialsScreen(Screen[None]):
         margin-bottom: 1;
     }
 
-    #creds-hint {
+    #creds-mode {
         color: $text-muted;
+        height: auto;
         margin-bottom: 1;
+    }
+
+    #creds-warning {
+        display: none;
+        color: $error;
+        border: round $error;
+        padding: 0 1;
+        margin-bottom: 1;
+    }
+
+    #creds-warning.visible {
+        display: block;
     }
 
     #creds-error {
@@ -640,36 +648,61 @@ class CredentialsScreen(Screen[None]):
     }
     """
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._keyring_available: bool | None = None  # None = still detecting
+
     def compose(self) -> ComposeResult:
-        env = _load_env()
-        existing_email = env.get("GARMIN_EMAIL", "")
         yield Header(show_clock=True)
         with Static(id="creds-box"):
             yield Static("Garmin Connect Credentials", id="creds-title")
-            yield Static(
-                "Saved to .env — never committed to version control.",
-                id="creds-hint",
-            )
-            yield Input(
-                placeholder="Email",
-                value=existing_email,
-                id="creds-email",
-            )
-            yield Input(
-                placeholder="Password",
-                password=True,
-                id="creds-password",
-            )
+            yield Static("[dim]Detecting keyring…[/]", id="creds-mode")
+            yield Static("", id="creds-warning")
+            yield Input(placeholder="Email", id="creds-email")
+            yield Input(placeholder="Password", password=True, id="creds-password")
             yield Static("", id="creds-error")
             yield Static("", id="creds-success")
         yield Footer()
 
     def on_mount(self) -> None:
-        email_input = self.query_one("#creds-email", Input)
-        if email_input.value:
+        from garmin_extract._credentials import load_credentials
+
+        # Pre-fill email from wherever creds are stored
+        email, _ = load_credentials()
+        if email:
+            self.query_one("#creds-email", Input).value = email
             self.query_one("#creds-password", Input).focus()
         else:
-            email_input.focus()
+            self.query_one("#creds-email", Input).focus()
+
+        self.run_worker(self._detect_keyring, thread=True, name="creds-keyring-detect")
+
+    def _detect_keyring(self) -> None:
+        from garmin_extract._credentials import detect_keyring
+
+        ok, detail = detect_keyring()
+        self.app.call_from_thread(self._apply_keyring_state, ok, detail)
+
+    def _apply_keyring_state(self, ok: bool, detail: str) -> None:
+        self._keyring_available = ok
+        mode = self.query_one("#creds-mode", Static)
+        warning = self.query_one("#creds-warning", Static)
+
+        if ok:
+            mode.update(f"[green]●[/]  Keyring: {detail}")
+        else:
+            mode.update(
+                "[yellow]⚠[/]  No secure keyring available"
+                " — credentials will be stored in [bold].env[/bold]"
+            )
+            warning.update(
+                "  [bold]⚠  PLAINTEXT WARNING[/bold]\n\n"
+                "  Saving will write your password to a plain-text file on disk.\n"
+                "  Anyone with read access to your filesystem can see it.\n\n"
+                "  [dim]enter[/dim]  →  save to .env (plaintext)\n"
+                "  [dim]esc  [/dim]  →  don't save — you'll be prompted at runtime"
+            )
+            warning.add_class("visible")
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if event.input.id == "creds-email":
@@ -678,6 +711,8 @@ class CredentialsScreen(Screen[None]):
         self._save()
 
     def _save(self) -> None:
+        from garmin_extract._credentials import save_to_env, save_to_keyring
+
         email = self.query_one("#creds-email", Input).value.strip()
         password = self.query_one("#creds-password", Input).value.strip()
         error = self.query_one("#creds-error", Static)
@@ -693,11 +728,16 @@ class CredentialsScreen(Screen[None]):
             return
 
         error.update("")
-        env = _load_env()
-        env["GARMIN_EMAIL"] = email
-        env["GARMIN_PASSWORD"] = password
-        _save_env(env)
-        success.update(f"✓  Saved — {email}")
+
+        if self._keyring_available:
+            ok, detail = save_to_keyring(email, password)
+            if ok:
+                success.update(f"✓  Saved to keyring — {email}")
+            else:
+                error.update(f"Keyring save failed: {detail}")
+        else:
+            save_to_env(email, password)
+            success.update(f"✓  Saved to .env — {email}")
 
     def action_back(self) -> None:
         self.app.pop_screen()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "google-auth-oauthlib>=1.0.0",
     "rich>=13.0.0",
     "textual>=0.50.0",
+    "keyring>=24.0.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -427,6 +427,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
+    { name = "keyring" },
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "requests-oauthlib" },
@@ -449,6 +450,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.0.0" },
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.0.0" },
+    { name = "keyring", specifier = ">=24.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "requests-oauthlib", specifier = ">=1.3.0" },
@@ -589,6 +591,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -598,6 +642,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -771,6 +832,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
 ]
 
 [[package]]
@@ -1285,6 +1355,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/0c/c16bc93ac2755bac0066a8ecbd2a2931a1735a6fffd99a2b9681c7e83e90/pytweening-1.2.0.tar.gz", hash = "sha256:243318b7736698066c5f362ec5c2b6434ecf4297c3c8e7caa8abfe6af4cac71b", size = 171241, upload-time = "2024-02-20T03:37:56.809Z" }
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1403,6 +1482,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/aa/23/3c5b816b0c4de8452a8ceef5be39b4cdba05d8a15c214673c7cf4f4b499a/sbvirtualdisplay-1.4.0.tar.gz", hash = "sha256:29a365b509cd7bfde4f758603b7b75703909b11cdf4245abc8f828ed35660d9b", size = 12631, upload-time = "2024-12-16T15:02:18.341Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/65/832a5d0953f03c0b9bc267c58813aa51957b27c0902743f8e4d11d020dd1/sbvirtualdisplay-1.4.0-py3-none-any.whl", hash = "sha256:516de155219aa342c4e090a3c5126cfe6b12416334bcba3255268e44a5e8a206", size = 12490, upload-time = "2024-12-16T15:02:17.195Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `garmin_extract/_credentials.py` — shared helpers: `detect_keyring()`, `load_credentials()`, `save_to_keyring()`, `save_to_env()`, `check_credentials()`
- `keyring>=24.0.0` added to dependencies (installs SecretService backend on Linux)
- `CredentialsScreen` fully redesigned:
  - Detects keyring on mount (async worker, smoke-tests write/read/delete)
  - Keyring available → normal form, saves silently to OS keyring
  - Keyring unavailable → red-bordered plaintext warning panel appears, enter saves to `.env`, esc skips (runtime-only)
  - Pre-fills email from wherever creds are already stored (keyring or .env)
- `PullProgressScreen` now loads credentials before launching subprocess:
  - Calls `load_credentials()` on mount
  - If no password found → `_RuntimeCredsModal` pops up (email + password, not saved)
  - Credentials injected as env vars into subprocess so keyring/runtime creds reach `garmin.py` even though it calls `load_dotenv()` internally
- SetupScreen status now shows source: `email (keyring)` or `email (.env)`
- Existing `.env` users are not broken — `load_credentials()` falls back to `.env`

## Test plan
- [ ] Keyring path: save creds in Setup → delete `.env` → pull works without prompt
- [ ] No-keyring path: warning panel appears, enter saves to `.env` with warning acknowledged
- [ ] Runtime path: no creds anywhere → modal prompts before pull, nothing written to disk
- [ ] Setup status line shows correct source label `(keyring)` or `(.env)`
- [ ] Rebuild CSV and zip import skip the credential check entirely

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)