### PR TITLE
release: v1.3.0 — navigation, keyring credentials, Fetch New

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ Once logged in, Chrome saves the session to a local browser profile and reuses i
 
 ## Features
 
-- **Interactive TUI** — a full terminal interface that walks you through setup, data pulls, and automation without touching the command line
+- **Interactive TUI** — a full terminal interface that walks you through setup, data pulls, and automation without touching the command line; navigate with arrow keys, `j/k`, number shortcuts, or `enter`
 - **30+ metrics per day** — steps, heart rate, sleep, HRV, stress, body battery, SpO2, respiration, training readiness, nutrition, activities, and more
 - **Per-activity detail** — 8 additional endpoints per workout (splits, HR zones, power zones, exercise sets, weather, and more)
 - **One-time profile pull** — devices, personal records, training plans, and gear saved to `profile.json`
+- **Fetch New** — automatically detects the most recent local date and pulls only the gap to yesterday; no manual date math required
 - **Historical backfill** from Garmin's bulk data export (`.zip` file)
 - **CSV export** — `garmin_daily.csv` (daily metrics) and `garmin_activities.csv` (per-workout)
 - **Google Drive / Sheets export** — upload CSVs to Drive or sync to a live Google Sheet, all from inside the TUI
+- **Secure credential storage** — passwords saved to OS keyring (SecretService / Credential Manager / Keychain) by default; `.env` fallback with plaintext warning if keyring is unavailable; runtime-only entry if no storage is desired
 - Partial failures are non-fatal — the daily file is written with whatever succeeded
 - Idempotent — safe to run multiple times; already-pulled dates are skipped by default
 
@@ -81,7 +83,7 @@ python -m garmin_extract
 The interactive TUI is the recommended way to get started. On launch you'll land on the main menu:
 
 ```
-  garmin-extract  v1.2.0
+  garmin-extract  v1.3.0
   Automated Garmin Connect data pipeline
 
   ┌─────────────────────────────────────────────────────┐
@@ -91,10 +93,12 @@ The interactive TUI is the recommended way to get started. On launch you'll land
   └─────────────────────────────────────────────────────┘
 ```
 
+All menus support keyboard navigation: `↑↓` or `j/k` to move, `enter` to select, number keys for direct access.
+
 **First-time setup order:**
 
 1. **Initial Setup → Prerequisites** — verifies Chrome, Xvfb (Linux), Python version, and packages. Installs missing prerequisites on Linux.
-2. **Initial Setup → Garmin Credentials** — enter your Garmin email and password. Saved to `.env`.
+2. **Initial Setup → Garmin Credentials** — enter your Garmin email and password. Saved to the OS keyring by default (encrypted at rest). If keyring is unavailable, you'll be offered `.env` storage with a plaintext warning, or you can skip saving and enter credentials at runtime before each pull.
 3. **Initial Setup → Gmail OAuth** *(optional but recommended)* — authorizes the Gmail API so MFA codes are fetched automatically. The same OAuth token also grants access to Google Drive and Sheets. See [Gmail MFA automation](#gmail-mfa-automation).
 4. **Pull Data** — choose a date range and pull. On the first pull, Chrome launches, logs in, handles MFA, and saves a session to `.garmin_browser_profile/`. Subsequent runs reuse that session.
 
@@ -286,6 +290,29 @@ Garmin's API endpoints are reverse-engineered from the Connect SPA and may chang
 - The API endpoints are **reverse-engineered from the Garmin Connect SPA**. They may change with Garmin app updates. If metrics start returning 404/empty responses, the endpoints may need to be re-mapped using Chrome DevTools → Network tab.
 
 ## Changelog
+
+### v1.3.0 — 2026-04-15 — Navigation, keyring credentials, Fetch New
+
+**Keyboard navigation across all menus** (↑↓ / j/k / enter):
+- Every menu screen — Main Menu, Pull Data, Setup, Automation, Drive/Sheets — now supports arrow keys, vim motions (`j/k`), and `enter` to select, in addition to existing number shortcuts
+
+**Keyring-first credential storage:**
+- Passwords are now saved to the OS keyring (SecretService on Linux, Credential Manager on Windows, Keychain on macOS) by default — encrypted at rest, never written to disk
+- If no secure keyring backend is available, `.env` storage is offered with a prominent plaintext warning
+- Third option: runtime-only entry — enter credentials before each pull, nothing saved anywhere
+- Setup screen detects keyring availability on mount and adjusts the UI accordingly
+
+**Fetch New** (Pull Data → `[0]`):
+- Scans `data/garmin/` for the most recent local date, computes the gap to yesterday, and launches a pull automatically — no manual date selection required
+- If already up to date, shows a toast notification
+- If no local data exists yet, falls through to the Full History prompt
+
+**Bug fixes:**
+- `b` back is now always visible and functional during an active pull — pressing it terminates the subprocess and returns to the menu immediately
+- Gmail `is_configured()` now checks that the OAuth token contains the `gmail.readonly` scope, not just that the token file exists — prevents a 90-second polling wait when only Drive/Sheets OAuth has been completed
+- Fixed `AttributeError: 'DataPullScreen' object has no attribute '_cursor'` crash on screen open
+
+---
 
 ### v1.2.0 — 2026-04-15 — Google Drive / Sheets export
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,32 @@ Failed metrics are recorded inline rather than aborting the pull:
 
 **One-time profile pull** (per session): devices, user profile, personal records, training plans, workouts, gear → `data/garmin/profile.json`.
 
+## Troubleshooting
+
+**Pull fails immediately or browser crashes (exit code 1, no metrics pulled)**
+
+The saved Chrome session in `.garmin_browser_profile/` may be stale or corrupted. Clear it to force a fresh login:
+
+```bash
+rm -rf .garmin_browser_profile/
+```
+
+Then re-run. Chrome will log in fresh, trigger MFA, and save a new session. This is the most common fix after long gaps between pulls or after Garmin rotates session tokens (~30 days).
+
+---
+
+**MFA modal never appears / pull hangs waiting for a code**
+
+Make sure Gmail automation is fully configured (Setup → Gmail MFA). If only Drive/Sheets OAuth was completed, the Gmail scope is missing and the puller will skip Gmail polling and show the manual MFA modal instead.
+
+---
+
+**Metrics return empty or 404**
+
+Garmin's API endpoints are reverse-engineered from the Connect SPA and may change with app updates. If data stops coming back, the endpoints likely need to be re-mapped using Chrome DevTools → Network tab while browsing Garmin Connect.
+
+---
+
 ## Known limitations
 
 - Tested on **Ubuntu 24.04**. Windows and macOS are supported but less tested.

--- a/garmin_extract/screens/data_pull.py
+++ b/garmin_extract/screens/data_pull.py
@@ -79,7 +79,7 @@ class DataPullScreen(Screen[None]):
 
     def _item(self, n: int, key: str, label: str, hint: str = "") -> str:
         """Render one menu item with cursor indicator if selected."""
-        sel = (n - 1) == self._cursor
+        sel = (n - 1) == getattr(self, "_cursor", 0)
         pre = "❯ " if sel else "  "
         lbl = f"[bold]{label}[/]" if sel else label
         h = f"  [dim]{hint}[/]" if hint else ""

--- a/garmin_extract/screens/data_pull.py
+++ b/garmin_extract/screens/data_pull.py
@@ -24,12 +24,37 @@ def _yesterday() -> str:
     return (date.today() - timedelta(days=1)).isoformat()
 
 
+def _find_fetch_new_range() -> tuple[str, int] | None:
+    """
+    Scan data/garmin/ for the most recent date file.
+    Returns (start_iso, days) covering next-unsynced → yesterday.
+    Returns None if already up to date.
+    Raises FileNotFoundError if no date files exist yet.
+    """
+    import re
+
+    data_dir = Path(__file__).parent.parent.parent / "data" / "garmin"
+    if not data_dir.exists():
+        raise FileNotFoundError("no data directory")
+    date_re = re.compile(r"^\d{4}-\d{2}-\d{2}\.json$")
+    dates = sorted(f.stem for f in data_dir.glob("*.json") if date_re.match(f.name))
+    if not dates:
+        raise FileNotFoundError("no date files")
+    latest = date.fromisoformat(dates[-1])
+    yesterday = date.today() - timedelta(days=1)
+    start = latest + timedelta(days=1)
+    if start > yesterday:
+        return None  # already up to date
+    return start.isoformat(), (yesterday - start).days + 1
+
+
 class DataPullScreen(Screen[None]):
     """Submenu for pulling data and rebuilding reports."""
 
-    _ITEM_COUNT = 7
+    _ITEM_COUNT = 8
 
     BINDINGS = [
+        Binding("0", "fetch_new", show=False),
         Binding("1", "pull_yesterday", show=False),
         Binding("2", "pull_7", show=False),
         Binding("3", "pull_30", show=False),
@@ -77,9 +102,9 @@ class DataPullScreen(Screen[None]):
     }
     """
 
-    def _item(self, n: int, key: str, label: str, hint: str = "") -> str:
+    def _item(self, pos: int, key: str, label: str, hint: str = "") -> str:
         """Render one menu item with cursor indicator if selected."""
-        sel = (n - 1) == getattr(self, "_cursor", 0)
+        sel = pos == getattr(self, "_cursor", 0)
         pre = "❯ " if sel else "  "
         lbl = f"[bold]{label}[/]" if sel else label
         h = f"  [dim]{hint}[/]" if hint else ""
@@ -91,6 +116,9 @@ class DataPullScreen(Screen[None]):
         r30 = _date_range_label(30)
         _ = self._item
         return (
+            f"\n"
+            f"  [bold dim]SYNC[/]\n  {'─' * 51}\n"
+            f"{_(0, '0', 'Fetch new', 'pull all dates not yet in local data')}\n"
             f"\n"
             f"  [bold dim]RECENT[/]\n  {'─' * 51}\n"
             f"{_(1, '1', 'Yesterday', yest)}\n"
@@ -112,7 +140,7 @@ class DataPullScreen(Screen[None]):
         yield Header(show_clock=True)
         yield Static(self._build_menu(), id="pull-menu")
         yield Static(
-            "↑↓  j/k  navigate  ·  enter  select  ·  1–7  direct  ·  b  back",
+            "↑↓  j/k  navigate  ·  enter  select  ·  0–7  direct  ·  b  back",
             id="pull-hint",
         )
         yield Footer()
@@ -135,6 +163,7 @@ class DataPullScreen(Screen[None]):
 
     def action_cursor_select(self) -> None:
         _actions = [
+            self.action_fetch_new,
             self.action_pull_yesterday,
             self.action_pull_7,
             self.action_pull_30,
@@ -165,35 +194,50 @@ class DataPullScreen(Screen[None]):
             )
         )
 
-    def action_pull_yesterday(self) -> None:
+    def action_fetch_new(self) -> None:
         self._cursor = 0
+        try:
+            result = _find_fetch_new_range()
+        except FileNotFoundError:
+            # No local data at all — let the user pick a start date
+            self.app.push_screen(FullHistoryScreen())
+            return
+        if result is None:
+            self.notify("Already up to date — no new dates to pull.", title="Fetch New")
+            return
+        start, days = result
+        end = (date.fromisoformat(start) + timedelta(days=days - 1)).isoformat()
+        self._push_progress(start, days, f"Fetch new  ({start}  →  {end})")
+
+    def action_pull_yesterday(self) -> None:
+        self._cursor = 1
         yest = _yesterday()
         self._push_progress(yest, 1, f"Yesterday  ({yest})")
 
     def action_pull_7(self) -> None:
-        self._cursor = 1
+        self._cursor = 2
         start = (date.today() - timedelta(days=7)).isoformat()
         self._push_progress(start, 7, f"Last 7 days  ({_date_range_label(7)})")
 
     def action_pull_30(self) -> None:
-        self._cursor = 2
+        self._cursor = 3
         start = (date.today() - timedelta(days=30)).isoformat()
         self._push_progress(start, 30, f"Last 30 days  ({_date_range_label(30)})")
 
     def action_pull_custom(self) -> None:
-        self._cursor = 3
+        self._cursor = 4
         self.app.push_screen(CustomDateScreen())
 
     def action_pull_history(self) -> None:
-        self._cursor = 4
+        self._cursor = 5
         self.app.push_screen(FullHistoryScreen())
 
     def action_import_zip(self) -> None:
-        self._cursor = 5
+        self._cursor = 6
         self.app.push_screen(ImportZipScreen())
 
     def action_rebuild_csvs(self) -> None:
-        self._cursor = 6
+        self._cursor = 7
         self._push_progress("", 0, "Rebuilding CSV reports", rebuild_only=True)
 
     def action_back(self) -> None:

--- a/garmin_extract/screens/pull_progress.py
+++ b/garmin_extract/screens/pull_progress.py
@@ -163,7 +163,7 @@ class PullProgressScreen(Screen[None]):
     """Full-screen live progress display for a Garmin data pull or CSV rebuild."""
 
     BINDINGS = [
-        Binding("b", "back", "Back", show=False),
+        Binding("b", "back", "Back", show=True),
         Binding("q", "quit", "Quit", show=True),
     ]
 
@@ -244,6 +244,7 @@ class PullProgressScreen(Screen[None]):
         self._mfa_shown = False
         self._email = ""
         self._password = ""
+        self._proc: subprocess.Popen | None = None
 
         # Determine display mode
         if days > 1:
@@ -377,13 +378,16 @@ class PullProgressScreen(Screen[None]):
                 cwd=str(ROOT),
                 env=env,
             )
+            self._proc = proc
             assert proc.stdout is not None
             for raw_line in iter(proc.stdout.readline, ""):
                 line = raw_line.rstrip("\n")
                 self.app.call_from_thread(self._on_line, line)
             proc.wait()
+            self._proc = None
             self.app.call_from_thread(self._on_done, proc.returncode)
         except Exception as exc:
+            self._proc = None
             self.app.call_from_thread(self._on_error, str(exc))
 
     # ── line parser (main thread) ──────────────────────────────────────────────
@@ -537,13 +541,11 @@ class PullProgressScreen(Screen[None]):
                 f"\n[red]Process exited with code {returncode}.[/red]"
                 "  Press  [bold]b[/bold]  to go back."
             )
-        self._enable_back()
 
     def _on_error(self, msg: str) -> None:
         self._done = True
         self.query_one("#log-panel", RichLog).write(f"\n[red]Error: {msg}[/red]")
         self._set_status("Error  —  press  b  to go back")
-        self._enable_back()
 
     # ── rendering ─────────────────────────────────────────────────────────────
 
@@ -584,21 +586,15 @@ class PullProgressScreen(Screen[None]):
     def _set_status(self, text: str) -> None:
         self.query_one("#status-label", Static).update(text)
 
-    def _enable_back(self) -> None:
-        try:
-            self.BINDINGS = [
-                Binding("b", "back", "Back", show=True),
-                Binding("q", "quit", "Quit", show=True),
-            ]
-            self.refresh_bindings()
-        except Exception:
-            pass
-
     # ── actions ───────────────────────────────────────────────────────────────
 
     def action_back(self) -> None:
-        if self._done:
-            self.app.pop_screen()
+        if self._proc is not None:
+            try:
+                self._proc.terminate()
+            except Exception:
+                pass
+        self.app.pop_screen()
 
     def action_quit(self) -> None:
         self.app.exit()

--- a/pullers/_gmail_mfa.py
+++ b/pullers/_gmail_mfa.py
@@ -172,5 +172,14 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
 
 
 def is_configured() -> bool:
-    """Return True if Gmail credentials are present and usable."""
-    return TOKEN_FILE.exists() and CREDENTIALS_FILE.exists()
+    """Return True if Gmail credentials are present and the token has the Gmail scope."""
+    if not TOKEN_FILE.exists() or not CREDENTIALS_FILE.exists():
+        return False
+    try:
+        import json as _json
+
+        tok = _json.loads(TOKEN_FILE.read_text())
+        scopes = tok.get("scopes") or []
+        return any("gmail" in s for s in scopes)
+    except Exception:
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "garmin-extract"
-version = "1.2.1"
+version = "1.3.0"
 description = "Automated Garmin Connect data pipeline using browser automation"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.2.1"
+version = "1.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary
- `[0] Fetch New` — auto-detects gap to yesterday and pulls it; toast if up to date; Full History prompt if no local data
- Keyboard navigation (↑↓ / j/k / enter) across all 5 menu screens
- Keyring-first credential storage — OS keyring by default, .env fallback w/ warning, runtime-only option
- `b` back always available during pull — terminates subprocess immediately
- Gmail `is_configured()` scope check — no more 90s poll when only Drive/Sheets token exists
- AttributeError crash fix on DataPullScreen open
- README Troubleshooting section + v1.3.0 changelog

Closes #17. Supersedes #18 (closed by #21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)