### PR TITLE
fix: suppress spurious Xvfb error on desktop Linux

### DIFF
--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -630,7 +630,7 @@ def main():
     try:
         print("Launching browser...")
         PROFILE_DIR.mkdir(exist_ok=True)
-        with SB(uc=True, headless=False, user_data_dir=str(PROFILE_DIR)) as sb:
+        with SB(uc=True, headless=False, xvfb=False, user_data_dir=str(PROFILE_DIR)) as sb:
             ensure_logged_in(sb)
 
             print("Getting display name...")


### PR DESCRIPTION
## Summary
- Pass `xvfb=False` to SeleniumBase `SB()` constructor to suppress the internal Xvfb startup attempt
- On desktop Linux, SeleniumBase was logging a scary "X11 display failed! Is Xvfb installed?" warning before falling back to the real display — purely cosmetic but alarming to users
- We already manage our own Xvfb for headless environments, so SeleniumBase's attempt was redundant

## Test plan
- [ ] Run a pull on desktop Linux — no more "X11 display failed" error
- [ ] Run a pull on headless Linux (cron) — still works via our own Xvfb

🤖 Generated with [Claude Code](https://claude.com/claude-code)