### PR TITLE
release: v1.4.0 — Windows GUI (PySide6)

### DIFF
--- a/garmin_extract/gui/main_window.py
+++ b/garmin_extract/gui/main_window.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QHBoxLayout,
-    QLabel,
     QListWidget,
     QMainWindow,
     QStackedWidget,
-    QVBoxLayout,
     QWidget,
 )
 
 from garmin_extract import __version__
+from garmin_extract.gui.screens.automation import AutomationPage
+from garmin_extract.gui.screens.pull_data import PullDataPage
 from garmin_extract.gui.screens.setup import SetupPage
 
 
@@ -44,34 +43,8 @@ class MainWindow(QMainWindow):
         # ── Content area ──────────────────────────────
         self.stack = QStackedWidget()
         self.stack.addWidget(SetupPage())
-        self.stack.addWidget(self._placeholder("Pull Data", "Download your Garmin health metrics"))
-        self.stack.addWidget(
-            self._placeholder("Automation", "Gmail MFA, scheduled pulls, Drive / Sheets")
-        )
+        self.stack.addWidget(PullDataPage())
+        self.stack.addWidget(AutomationPage())
         layout.addWidget(self.stack)
 
         self.sidebar.currentRowChanged.connect(self.stack.setCurrentIndex)
-
-    @staticmethod
-    def _placeholder(title: str, subtitle: str) -> QWidget:
-        """Build a centered placeholder page for a section not yet implemented."""
-        page = QWidget()
-        vbox = QVBoxLayout(page)
-        vbox.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        heading = QLabel(title)
-        heading.setObjectName("heading")
-        heading.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        vbox.addWidget(heading)
-
-        sub = QLabel(subtitle)
-        sub.setObjectName("subheading")
-        sub.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        vbox.addWidget(sub)
-
-        coming = QLabel("Coming soon")
-        coming.setObjectName("subheading")
-        coming.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        vbox.addWidget(coming)
-
-        return page

--- a/garmin_extract/gui/main_window.py
+++ b/garmin_extract/gui/main_window.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
 )
 
 from garmin_extract import __version__
+from garmin_extract.gui.screens.setup import SetupPage
 
 
 class MainWindow(QMainWindow):
@@ -42,9 +43,7 @@ class MainWindow(QMainWindow):
 
         # ── Content area ──────────────────────────────
         self.stack = QStackedWidget()
-        self.stack.addWidget(
-            self._placeholder("Initial Setup", "Configure credentials and prerequisites")
-        )
+        self.stack.addWidget(SetupPage())
         self.stack.addWidget(self._placeholder("Pull Data", "Download your Garmin health metrics"))
         self.stack.addWidget(
             self._placeholder("Automation", "Gmail MFA, scheduled pulls, Drive / Sheets")

--- a/garmin_extract/gui/screens/__init__.py
+++ b/garmin_extract/gui/screens/__init__.py
@@ -1,0 +1,1 @@
+"""GUI screen/page widgets."""

--- a/garmin_extract/gui/screens/automation.py
+++ b/garmin_extract/gui/screens/automation.py
@@ -1,0 +1,340 @@
+"""Automation page — Gmail MFA status, scheduled pulls, Drive/Sheets export."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import Thread
+
+from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+ROOT = Path(__file__).parent.parent.parent.parent
+GMAIL_CREDS_FILE = ROOT / "google_credentials.json"
+GMAIL_TOKEN_FILE = ROOT / ".google_token.json"
+DRIVE_CONFIG_FILE = ROOT / ".drive_config.json"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _check_gmail_automation() -> tuple[str, str]:
+    """Return (status, detail) where status is 'ok' | 'partial' | 'unconfigured'."""
+    has_creds = GMAIL_CREDS_FILE.exists()
+    has_token = GMAIL_TOKEN_FILE.exists()
+
+    if not has_creds and not has_token:
+        return "unconfigured", "Not set up"
+    if not has_creds:
+        return "partial", "google_credentials.json missing"
+    if not has_token:
+        return "partial", "Not yet authorized"
+
+    try:
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+
+        tok = json.loads(GMAIL_TOKEN_FILE.read_text())
+        creds = Credentials(
+            token=tok.get("token"),
+            refresh_token=tok.get("refresh_token"),
+            token_uri=tok.get("token_uri"),
+            client_id=tok.get("client_id"),
+            client_secret=tok.get("client_secret"),
+            scopes=tok.get("scopes"),
+        )
+        if creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        return "ok", "Gmail automation is active — MFA codes fetched automatically"
+    except Exception as exc:
+        return "partial", f"Token validation failed: {exc}"
+
+
+def _check_drive_auth() -> tuple[str, str]:
+    """Return (status, detail) for Drive/Sheets auth."""
+    try:
+        from garmin_extract._google_drive import check_auth
+
+        return check_auth()
+    except Exception as exc:
+        return "error", str(exc)
+
+
+def _load_drive_config() -> dict:
+    try:
+        return json.loads(DRIVE_CONFIG_FILE.read_text()) if DRIVE_CONFIG_FILE.exists() else {}
+    except Exception:
+        return {}
+
+
+# ── Signals ──────────────────────────────────────────────────────────────────
+
+
+class _AutoSignals(QObject):
+    gmail_done = Signal(str, str, str)  # status, detail, icon_color
+    drive_auth_done = Signal(str, str)  # auth_text, last_export_text
+    drive_op_done = Signal(str)  # result text
+
+
+# ── Status card (reused from setup) ─────────────────────────────────────────
+
+
+class _SectionCard(QFrame):
+    """A card for displaying automation section status."""
+
+    def __init__(self, title: str, subtitle: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setStyleSheet("""
+            QFrame {
+                background-color: #313244;
+                border: 1px solid #45475a;
+                border-radius: 8px;
+                padding: 16px;
+            }
+            """)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 12, 16, 12)
+        layout.setSpacing(6)
+
+        self._title = QLabel(title)
+        self._title.setStyleSheet("font-size: 16px; font-weight: bold; background: transparent;")
+        layout.addWidget(self._title)
+
+        self._subtitle = QLabel(subtitle)
+        self._subtitle.setStyleSheet("font-size: 13px; color: #6c7086; background: transparent;")
+        layout.addWidget(self._subtitle)
+
+        self._status = QLabel("Checking...")
+        self._status.setStyleSheet("font-size: 13px; color: #6c7086; background: transparent;")
+        layout.addWidget(self._status)
+
+        self._actions_layout = QHBoxLayout()
+        self._actions_layout.setContentsMargins(0, 8, 0, 0)
+        layout.addLayout(self._actions_layout)
+
+    def set_status(self, text: str, color: str = "#6c7086") -> None:
+        self._status.setText(text)
+        self._status.setStyleSheet(f"font-size: 13px; color: {color}; background: transparent;")
+
+    def add_action_button(self, label: str, callback: object) -> QPushButton:
+        btn = QPushButton(label)
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        btn.setStyleSheet("""
+            QPushButton {
+                padding: 6px 14px;
+                font-size: 13px;
+                background-color: #45475a;
+                border: 1px solid #585b70;
+                border-radius: 4px;
+                color: #cdd6f4;
+            }
+            QPushButton:hover {
+                background-color: #585b70;
+                border-color: #89b4fa;
+            }
+            QPushButton:pressed {
+                background-color: #89b4fa;
+                color: #1e1e2e;
+            }
+            """)
+        btn.clicked.connect(callback)
+        self._actions_layout.addWidget(btn)
+        return btn
+
+
+# ── Automation page ──────────────────────────────────────────────────────────
+
+
+class AutomationPage(QWidget):
+    """The Automation page shown in the main window's stacked widget."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(40, 32, 40, 32)
+        layout.setSpacing(8)
+
+        heading = QLabel("Automation")
+        heading.setObjectName("heading")
+        layout.addWidget(heading)
+
+        sub = QLabel("Gmail MFA, scheduled pulls, Drive / Sheets")
+        sub.setObjectName("subheading")
+        layout.addWidget(sub)
+
+        layout.addSpacing(16)
+
+        # ── Gmail MFA card ────────────────────────────
+        self._gmail_card = _SectionCard("Gmail MFA", "Automatic MFA code retrieval from Gmail")
+        layout.addWidget(self._gmail_card)
+
+        layout.addSpacing(4)
+
+        # ── Scheduled Pulls card ──────────────────────
+        self._sched_card = _SectionCard(
+            "Scheduled Pulls",
+            "Windows Task Scheduler — coming in issue #31",
+        )
+        self._sched_card.set_status("Not yet implemented", "#6c7086")
+        layout.addWidget(self._sched_card)
+
+        layout.addSpacing(4)
+
+        # ── Drive / Sheets card ───────────────────────
+        self._drive_card = _SectionCard("Google Drive / Sheets", "Export data to Google services")
+        self._drive_upload_btn = self._drive_card.add_action_button(
+            "Upload CSVs to Drive", self._do_drive
+        )
+        self._drive_sheets_btn = self._drive_card.add_action_button(
+            "Sync to Sheets", self._do_sheets
+        )
+        self._drive_both_btn = self._drive_card.add_action_button("Both", self._do_both)
+        layout.addWidget(self._drive_card)
+
+        layout.addStretch()
+
+        # ── Status feedback ───────────────────────────
+        self._feedback = QLabel()
+        self._feedback.setStyleSheet("color: #6c7086; font-size: 13px;")
+        self._feedback.setWordWrap(True)
+        layout.addWidget(self._feedback)
+
+        # Wire up signals and run initial checks
+        self._signals = _AutoSignals()
+        self._signals.gmail_done.connect(self._on_gmail_done)
+        self._signals.drive_auth_done.connect(self._on_drive_auth_done)
+        self._signals.drive_op_done.connect(self._on_drive_op_done)
+        self.refresh_status()
+
+    def refresh_status(self) -> None:
+        Thread(target=self._check_gmail, daemon=True).start()
+        Thread(target=self._check_drive, daemon=True).start()
+
+    def _check_gmail(self) -> None:
+        status, detail = _check_gmail_automation()
+        if status == "ok":
+            self._signals.gmail_done.emit(status, detail, "#a6e3a1")
+        elif status == "partial":
+            self._signals.gmail_done.emit(status, detail, "#f9e2af")
+        else:
+            self._signals.gmail_done.emit(status, detail, "#6c7086")
+
+    def _on_gmail_done(self, status: str, detail: str, color: str) -> None:
+        if status == "ok":
+            self._gmail_card.set_status("\u2713 " + detail, color)
+        elif status == "partial":
+            self._gmail_card.set_status("\u26a0 " + detail, color)
+        else:
+            self._gmail_card.set_status(detail, color)
+
+    def _check_drive(self) -> None:
+        status, detail = _check_drive_auth()
+        cfg = _load_drive_config()
+        last = cfg.get("last_export", "")
+        last_text = ""
+        if last:
+            try:
+                from datetime import datetime
+
+                dt = datetime.fromisoformat(last).astimezone(None)
+                last_text = f"Last export: {dt.strftime('%Y-%m-%d %H:%M')}"
+            except Exception:
+                last_text = f"Last export: {last[:19]}"
+
+        if status == "ok":
+            auth_text = "\u2713 Drive and Sheets authorized"
+        elif status == "missing_scopes":
+            auth_text = f"\u26a0 {detail}"
+        else:
+            auth_text = detail
+
+        self._signals.drive_auth_done.emit(auth_text, last_text)
+
+    def _on_drive_auth_done(self, auth_text: str, last_text: str) -> None:
+        combined = auth_text
+        if last_text:
+            combined += f"  |  {last_text}"
+        self._drive_card.set_status(combined)
+
+    # ── Drive/Sheets actions ─────────────────────────────────────────────
+
+    def _set_buttons_enabled(self, enabled: bool) -> None:
+        self._drive_upload_btn.setEnabled(enabled)
+        self._drive_sheets_btn.setEnabled(enabled)
+        self._drive_both_btn.setEnabled(enabled)
+
+    def _do_drive(self) -> None:
+        self._set_buttons_enabled(False)
+        self._feedback.setText("Uploading CSVs to Drive...")
+        Thread(target=self._run_drive, daemon=True).start()
+
+    def _do_sheets(self) -> None:
+        self._set_buttons_enabled(False)
+        self._feedback.setText("Syncing to Google Sheets...")
+        Thread(target=self._run_sheets, daemon=True).start()
+
+    def _do_both(self) -> None:
+        self._set_buttons_enabled(False)
+        self._feedback.setText("Uploading CSVs and syncing Sheets...")
+        Thread(target=self._run_both, daemon=True).start()
+
+    def _run_drive(self) -> None:
+        try:
+            from garmin_extract._google_drive import upload_csvs_to_drive
+
+            result = upload_csvs_to_drive()
+            if result["ok"]:
+                names = ", ".join(f["name"] for f in result["files"])
+                self._signals.drive_op_done.emit(f"\u2713 Uploaded: {names}")
+            else:
+                self._signals.drive_op_done.emit(f"Error: {result['error']}")
+        except Exception as exc:
+            self._signals.drive_op_done.emit(f"Error: {exc}")
+
+    def _run_sheets(self) -> None:
+        try:
+            from garmin_extract._google_drive import sync_to_sheets
+
+            result = sync_to_sheets()
+            if result["ok"]:
+                self._signals.drive_op_done.emit("\u2713 Google Sheet updated")
+            else:
+                self._signals.drive_op_done.emit(f"Error: {result['error']}")
+        except Exception as exc:
+            self._signals.drive_op_done.emit(f"Error: {exc}")
+
+    def _run_both(self) -> None:
+        try:
+            from garmin_extract._google_drive import sync_to_sheets, upload_csvs_to_drive
+
+            lines = []
+            drive_result = upload_csvs_to_drive()
+            if drive_result["ok"]:
+                names = ", ".join(f["name"] for f in drive_result["files"])
+                lines.append(f"\u2713 Drive: {names}")
+            else:
+                lines.append(f"Drive error: {drive_result['error']}")
+
+            sheets_result = sync_to_sheets()
+            if sheets_result["ok"]:
+                lines.append("\u2713 Sheets updated")
+            else:
+                lines.append(f"Sheets error: {sheets_result['error']}")
+
+            self._signals.drive_op_done.emit("  |  ".join(lines))
+        except Exception as exc:
+            self._signals.drive_op_done.emit(f"Error: {exc}")
+
+    def _on_drive_op_done(self, text: str) -> None:
+        self._feedback.setText(text)
+        self._set_buttons_enabled(True)
+        self.refresh_status()

--- a/garmin_extract/gui/screens/pull_data.py
+++ b/garmin_extract/gui/screens/pull_data.py
@@ -1,0 +1,360 @@
+"""Pull Data page — all 8 pull options plus date/file dialogs."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+def _yesterday() -> str:
+    return (date.today() - timedelta(days=1)).isoformat()
+
+
+def _date_range_label(days: int) -> str:
+    today = date.today()
+    start = today - timedelta(days=days)
+    end = today - timedelta(days=1)
+    return f"{start.isoformat()}  \u2192  {end.isoformat()}"
+
+
+def _parse_date(s: str) -> str | None:
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y", "%m-%d-%Y", "%m-%d-%y"):
+        try:
+            return datetime.strptime(s.strip(), fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return None
+
+
+def _find_fetch_new_range() -> tuple[str, int] | None:
+    """Returns (start_iso, days) or None if up to date. Raises FileNotFoundError."""
+    import re
+
+    data_dir = Path(__file__).parent.parent.parent.parent / "data" / "garmin"
+    if not data_dir.exists():
+        raise FileNotFoundError("no data directory")
+    date_re = re.compile(r"^\d{4}-\d{2}-\d{2}\.json$")
+    dates = sorted(f.stem for f in data_dir.glob("*.json") if date_re.match(f.name))
+    if not dates:
+        raise FileNotFoundError("no date files")
+    latest = date.fromisoformat(dates[-1])
+    yesterday = date.today() - timedelta(days=1)
+    start = latest + timedelta(days=1)
+    if start > yesterday:
+        return None
+    return start.isoformat(), (yesterday - start).days + 1
+
+
+# ── Section header widget ────────────────────────────────────────────────────
+
+
+class _SectionHeader(QLabel):
+    """A dim section header label (SYNC, RECENT, CUSTOM, etc.)."""
+
+    def __init__(self, text: str, parent: QWidget | None = None) -> None:
+        super().__init__(text, parent)
+        self.setStyleSheet(
+            "font-size: 12px; font-weight: bold; color: #6c7086;"
+            " letter-spacing: 1px; background: transparent;"
+            " border-bottom: 1px solid #45475a; padding-bottom: 4px;"
+        )
+
+
+# ── Action button widget ─────────────────────────────────────────────────────
+
+
+class _ActionButton(QPushButton):
+    """A menu-style button matching the TUI's pull options."""
+
+    def __init__(self, label: str, hint: str = "", parent: QWidget | None = None) -> None:
+        display = f"{label}    {hint}" if hint else label
+        super().__init__(display, parent)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setStyleSheet("""
+            QPushButton {
+                text-align: left;
+                padding: 10px 16px;
+                background-color: transparent;
+                border: 1px solid transparent;
+                border-radius: 6px;
+                font-size: 14px;
+                color: #cdd6f4;
+            }
+            QPushButton:hover {
+                background-color: #313244;
+                border-color: #45475a;
+            }
+            QPushButton:pressed {
+                background-color: #45475a;
+            }
+            """)
+
+
+# ── Date input dialog ────────────────────────────────────────────────────────
+
+
+class _DateDialog(QDialog):
+    """Dialog for entering a start date and optional day count."""
+
+    def __init__(
+        self,
+        title: str,
+        show_days: bool = False,
+        hint: str = "",
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(title)
+        self.setMinimumWidth(400)
+        self.setModal(True)
+
+        self.result_start: str = ""
+        self.result_days: int = 1
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(10)
+
+        if hint:
+            hint_label = QLabel(hint)
+            hint_label.setWordWrap(True)
+            hint_label.setStyleSheet("color: #6c7086; font-size: 13px;")
+            layout.addWidget(hint_label)
+
+        layout.addWidget(QLabel("Start date"))
+        self._date_input = QLineEdit()
+        self._date_input.setPlaceholderText("YYYY-MM-DD  or  MM/DD/YYYY")
+        layout.addWidget(self._date_input)
+
+        if show_days:
+            layout.addWidget(QLabel("Number of days"))
+            self._days_input = QLineEdit()
+            self._days_input.setPlaceholderText("Default: 1")
+            layout.addWidget(self._days_input)
+        else:
+            self._days_input = None
+
+        self._error = QLabel()
+        self._error.setStyleSheet("color: #f38ba8;")
+        self._error.hide()
+        layout.addWidget(self._error)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        btn_layout.addWidget(cancel)
+        ok = QPushButton("Pull")
+        ok.clicked.connect(self._validate)
+        btn_layout.addWidget(ok)
+        layout.addLayout(btn_layout)
+
+        self._date_input.returnPressed.connect(self._validate)
+
+    def _validate(self) -> None:
+        raw = self._date_input.text().strip()
+        parsed = _parse_date(raw)
+        if not parsed:
+            self._error.setText(f"Cannot parse '{raw}' — try 2025-04-07")
+            self._error.show()
+            return
+
+        self.result_start = parsed
+
+        if self._days_input:
+            days_raw = self._days_input.text().strip()
+            self.result_days = int(days_raw) if days_raw.isdigit() and int(days_raw) > 0 else 1
+        else:
+            start_dt = datetime.strptime(parsed, "%Y-%m-%d").date()
+            yesterday = date.today() - timedelta(days=1)
+            self.result_days = (yesterday - start_dt).days + 1
+            if self.result_days <= 0:
+                self._error.setText("Start date must be before today.")
+                self._error.show()
+                return
+
+        self.accept()
+
+
+# ── Pull Data page ───────────────────────────────────────────────────────────
+
+
+class PullDataPage(QWidget):
+    """The Pull Data page shown in the main window's stacked widget."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(40, 32, 40, 32)
+        layout.setSpacing(4)
+
+        heading = QLabel("Pull Data")
+        heading.setObjectName("heading")
+        layout.addWidget(heading)
+
+        sub = QLabel("Download your Garmin health metrics")
+        sub.setObjectName("subheading")
+        layout.addWidget(sub)
+
+        layout.addSpacing(16)
+
+        # ── SYNC ──────────────────────────────────────
+        layout.addWidget(_SectionHeader("SYNC"))
+        btn = _ActionButton("Fetch new", "pull all dates not yet in local data")
+        btn.clicked.connect(self._fetch_new)
+        layout.addWidget(btn)
+
+        layout.addSpacing(8)
+
+        # ── RECENT ────────────────────────────────────
+        layout.addWidget(_SectionHeader("RECENT"))
+        btn = _ActionButton("Yesterday", _yesterday())
+        btn.clicked.connect(self._pull_yesterday)
+        layout.addWidget(btn)
+
+        btn = _ActionButton("Last 7 days", _date_range_label(7))
+        btn.clicked.connect(self._pull_7)
+        layout.addWidget(btn)
+
+        btn = _ActionButton("Last 30 days", _date_range_label(30))
+        btn.clicked.connect(self._pull_30)
+        layout.addWidget(btn)
+
+        layout.addSpacing(8)
+
+        # ── CUSTOM ────────────────────────────────────
+        layout.addWidget(_SectionHeader("CUSTOM"))
+        btn = _ActionButton("Specific date or range")
+        btn.clicked.connect(self._pull_custom)
+        layout.addWidget(btn)
+
+        btn = _ActionButton("Full history", "(from a date you choose)")
+        btn.clicked.connect(self._pull_history)
+        layout.addWidget(btn)
+
+        layout.addSpacing(8)
+
+        # ── IMPORT ────────────────────────────────────
+        layout.addWidget(_SectionHeader("IMPORT"))
+        btn = _ActionButton("Import from Garmin bulk export", ".zip")
+        btn.clicked.connect(self._import_zip)
+        layout.addWidget(btn)
+
+        layout.addSpacing(8)
+
+        # ── REPORTS ───────────────────────────────────
+        layout.addWidget(_SectionHeader("REPORTS"))
+        btn = _ActionButton("Rebuild CSV reports", "from existing data")
+        btn.clicked.connect(self._rebuild_csvs)
+        layout.addWidget(btn)
+
+        layout.addStretch()
+
+    # ── Actions ───────────────────────────────────────────────────────────
+
+    def _start_pull(self, start_date: str, days: int, label: str, **kwargs: object) -> None:
+        """Open the pull progress screen. Placeholder until #29 is built."""
+        QMessageBox.information(
+            self,
+            "Pull Started",
+            f"{label}\n\nStart: {start_date}\nDays: {days}\n\n"
+            "(Progress screen coming in issue #29)",
+        )
+
+    def _fetch_new(self) -> None:
+        try:
+            result = _find_fetch_new_range()
+        except FileNotFoundError:
+            dlg = _DateDialog(
+                "Full History Pull",
+                hint="No local data found. Choose a start date to begin pulling.",
+                parent=self,
+            )
+            if dlg.exec() == QDialog.DialogCode.Accepted:
+                end = date.fromisoformat(dlg.result_start) + timedelta(days=dlg.result_days - 1)
+                self._start_pull(
+                    dlg.result_start,
+                    dlg.result_days,
+                    f"Full history  ({dlg.result_start} \u2192 {end.isoformat()})",
+                )
+            return
+
+        if result is None:
+            QMessageBox.information(
+                self, "Fetch New", "Already up to date \u2014 no new dates to pull."
+            )
+            return
+
+        start, days = result
+        end = (date.fromisoformat(start) + timedelta(days=days - 1)).isoformat()
+        self._start_pull(start, days, f"Fetch new  ({start} \u2192 {end})")
+
+    def _pull_yesterday(self) -> None:
+        yest = _yesterday()
+        self._start_pull(yest, 1, f"Yesterday  ({yest})")
+
+    def _pull_7(self) -> None:
+        start = (date.today() - timedelta(days=7)).isoformat()
+        self._start_pull(start, 7, f"Last 7 days  ({_date_range_label(7)})")
+
+    def _pull_30(self) -> None:
+        start = (date.today() - timedelta(days=30)).isoformat()
+        self._start_pull(start, 30, f"Last 30 days  ({_date_range_label(30)})")
+
+    def _pull_custom(self) -> None:
+        dlg = _DateDialog(
+            "Custom Date Pull",
+            show_days=True,
+            hint="Formats: YYYY-MM-DD  \u00b7  MM/DD/YYYY  \u00b7  MM/DD/YY",
+            parent=self,
+        )
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            self._start_pull(
+                dlg.result_start,
+                dlg.result_days,
+                f"Custom  ({dlg.result_start}, {dlg.result_days}d)",
+            )
+
+    def _pull_history(self) -> None:
+        dlg = _DateDialog(
+            "Full History Pull",
+            hint=(
+                "Pulls every day from your chosen start date through yesterday.\n"
+                "Formats: YYYY-MM-DD  \u00b7  MM/DD/YYYY  \u00b7  MM/DD/YY"
+            ),
+            parent=self,
+        )
+        if dlg.exec() == QDialog.DialogCode.Accepted:
+            yesterday = (date.today() - timedelta(days=1)).isoformat()
+            self._start_pull(
+                dlg.result_start,
+                dlg.result_days,
+                f"Full history  ({dlg.result_start} \u2192 {yesterday})",
+            )
+
+    def _import_zip(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select Garmin Export",
+            "",
+            "Zip files (*.zip);;All files (*)",
+        )
+        if not path:
+            return
+        self._start_pull("", 0, "Garmin bulk export import", zip_path=path)
+
+    def _rebuild_csvs(self) -> None:
+        self._start_pull("", 0, "Rebuilding CSV reports", rebuild_only=True)

--- a/garmin_extract/gui/screens/pull_data.py
+++ b/garmin_extract/gui/screens/pull_data.py
@@ -266,13 +266,19 @@ class PullDataPage(QWidget):
     # ── Actions ───────────────────────────────────────────────────────────
 
     def _start_pull(self, start_date: str, days: int, label: str, **kwargs: object) -> None:
-        """Open the pull progress screen. Placeholder until #29 is built."""
-        QMessageBox.information(
-            self,
-            "Pull Started",
-            f"{label}\n\nStart: {start_date}\nDays: {days}\n\n"
-            "(Progress screen coming in issue #29)",
+        """Open the pull progress dialog."""
+        from garmin_extract.gui.screens.pull_progress import PullProgressDialog
+
+        dlg = PullProgressDialog(
+            start_date=start_date,
+            days=days,
+            label=label,
+            no_skip=bool(kwargs.get("no_skip")),
+            rebuild_only=bool(kwargs.get("rebuild_only")),
+            zip_path=str(kwargs.get("zip_path", "")),
+            parent=self,
         )
+        dlg.exec()
 
     def _fetch_new(self) -> None:
         try:

--- a/garmin_extract/gui/screens/pull_progress.py
+++ b/garmin_extract/gui/screens/pull_progress.py
@@ -1,0 +1,637 @@
+"""Pull Progress screen — live log, metrics panel, MFA modal, cancel."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import date, timedelta
+from pathlib import Path
+from threading import Thread
+
+from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QProgressBar,
+    QPushButton,
+    QSplitter,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+ROOT = Path(__file__).parent.parent.parent.parent
+MFA_FILE = ROOT / ".mfa_code"
+
+
+# ── Signals ──────────────────────────────────────────────────────────────────
+
+
+class _PullSignals(QObject):
+    log_line = Signal(str)
+    day_start = Signal(str, int)  # date_str, n_metrics
+    day_skipped = Signal(str)  # date_str
+    metric_done = Signal(str, bool)  # name, is_ok
+    mfa_needed = Signal()
+    finished = Signal(int)  # return code
+    error = Signal(str)
+
+
+# ── MFA dialog ───────────────────────────────────────────────────────────────
+
+
+class _MfaDialog(QDialog):
+    """Modal dialog to capture an MFA code."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("MFA Code Required")
+        self.setMinimumWidth(400)
+        self.setModal(True)
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(10)
+
+        title = QLabel("MFA Code Required")
+        title.setStyleSheet("font-size: 16px; font-weight: bold; color: #f9e2af;")
+        layout.addWidget(title)
+
+        hint = QLabel("Check your email for a 6-digit code and enter it below.")
+        hint.setStyleSheet("color: #6c7086;")
+        layout.addWidget(hint)
+
+        self._code_input = QLineEdit()
+        self._code_input.setPlaceholderText("000000")
+        self._code_input.setMaxLength(6)
+        self._code_input.returnPressed.connect(self._submit)
+        layout.addWidget(self._code_input)
+
+        self._error = QLabel()
+        self._error.setStyleSheet("color: #f38ba8;")
+        self._error.hide()
+        layout.addWidget(self._error)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        btn_layout.addWidget(cancel)
+        ok = QPushButton("Submit")
+        ok.clicked.connect(self._submit)
+        btn_layout.addWidget(ok)
+        layout.addLayout(btn_layout)
+
+    def _submit(self) -> None:
+        code = self._code_input.text().strip()
+        if not code:
+            self._error.setText("Please enter the 6-digit code.")
+            self._error.show()
+            return
+        MFA_FILE.write_text(code + "\n")
+        self.accept()
+
+
+# ── Runtime credentials dialog ───────────────────────────────────────────────
+
+
+class _RuntimeCredsDialog(QDialog):
+    """Dialog for entering credentials at runtime when none are saved."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Enter Garmin Connect Credentials")
+        self.setMinimumWidth(450)
+        self.setModal(True)
+
+        self.result_email = ""
+        self.result_password = ""
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(10)
+
+        hint = QLabel("No saved credentials found. These will not be stored.")
+        hint.setStyleSheet("color: #6c7086;")
+        layout.addWidget(hint)
+
+        layout.addWidget(QLabel("Email"))
+        self._email = QLineEdit()
+        self._email.setPlaceholderText("you@example.com")
+        layout.addWidget(self._email)
+
+        layout.addWidget(QLabel("Password"))
+        self._password = QLineEdit()
+        self._password.setEchoMode(QLineEdit.EchoMode.Password)
+        self._password.setPlaceholderText("Garmin Connect password")
+        self._password.returnPressed.connect(self._submit)
+        layout.addWidget(self._password)
+
+        self._error = QLabel()
+        self._error.setStyleSheet("color: #f38ba8;")
+        self._error.hide()
+        layout.addWidget(self._error)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        btn_layout.addWidget(cancel)
+        ok = QPushButton("Continue")
+        ok.clicked.connect(self._submit)
+        btn_layout.addWidget(ok)
+        layout.addLayout(btn_layout)
+
+    def _submit(self) -> None:
+        email = self._email.text().strip()
+        password = self._password.text().strip()
+        if not email:
+            self._error.setText("Email is required.")
+            self._error.show()
+            self._email.setFocus()
+            return
+        if not password:
+            self._error.setText("Password is required.")
+            self._error.show()
+            self._password.setFocus()
+            return
+        self.result_email = email
+        self.result_password = password
+        self.accept()
+
+
+# ── Day state for multi-day pulls ────────────────────────────────────────────
+
+
+@dataclass
+class _DayState:
+    date_str: str
+    total: int = 0
+    done: int = 0
+    failed: int = 0
+    status: str = "pending"  # pending | active | done | skipped
+
+
+# ── Pull Progress Dialog ─────────────────────────────────────────────────────
+
+
+class PullProgressDialog(QDialog):
+    """Full pull progress view — split log + metrics panel, progress bar, cancel."""
+
+    def __init__(
+        self,
+        start_date: str,
+        days: int,
+        label: str,
+        no_skip: bool = False,
+        rebuild_only: bool = False,
+        zip_path: str = "",
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(label)
+        self.setMinimumSize(900, 600)
+        self.resize(1000, 700)
+        self.setModal(True)
+
+        self._start_date = start_date
+        self._days = days
+        self._label = label
+        self._no_skip = no_skip
+        self._rebuild_only = rebuild_only
+        self._zip_path = zip_path
+        self._proc: subprocess.Popen | None = None
+        self._mfa_shown = False
+        self._email = ""
+        self._password = ""
+
+        # Display mode
+        if days > 1:
+            self._mode = "day"
+            self._day_states = self._init_day_states()
+            self._current_day_index = -1
+            self._metrics_per_day = 0
+        elif days == 1:
+            self._mode = "metric"
+            self._live_metrics: list[tuple[str, str]] = []
+            self._day_total = 0
+            self._day_done = 0
+        else:
+            self._mode = "simple"
+
+        self._overall_done = 0
+        self._overall_total = max(days, 1)
+
+        self._build_ui()
+        self._wire_signals()
+
+        # Check credentials then start
+        if self._rebuild_only or self._zip_path:
+            self._start_pull()
+        else:
+            self._check_creds_and_start()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # ── Split view: log + metrics ─────────────────
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Log panel (left)
+        self._log = QTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setStyleSheet(
+            "background-color: #1e1e2e; color: #cdd6f4; font-family: monospace;"
+            " font-size: 13px; border: none; border-right: 1px solid #45475a;"
+        )
+        splitter.addWidget(self._log)
+
+        # Metrics panel (right)
+        right = QWidget()
+        right_layout = QVBoxLayout(right)
+        right_layout.setContentsMargins(12, 12, 12, 12)
+
+        self._header = QLabel(self._label)
+        self._header.setStyleSheet(
+            "font-size: 16px; font-weight: bold; color: #89b4fa; background: transparent;"
+        )
+        right_layout.addWidget(self._header)
+
+        self._subheader = QLabel()
+        self._subheader.setStyleSheet("color: #6c7086; background: transparent;")
+        right_layout.addWidget(self._subheader)
+
+        self._metric_list = QTextEdit()
+        self._metric_list.setReadOnly(True)
+        self._metric_list.setStyleSheet(
+            "background-color: transparent; color: #cdd6f4;" " font-size: 13px; border: none;"
+        )
+        self._metric_list.setText(self._initial_panel_body())
+        right_layout.addWidget(self._metric_list)
+
+        splitter.addWidget(right)
+        splitter.setSizes([600, 400])
+        layout.addWidget(splitter)
+
+        # ── Bottom bar: progress + status + cancel ────
+        bottom = QWidget()
+        bottom.setStyleSheet("background-color: #313244; border-top: 1px solid #45475a;")
+        bottom_layout = QVBoxLayout(bottom)
+        bottom_layout.setContentsMargins(12, 8, 12, 8)
+        bottom_layout.setSpacing(4)
+
+        self._progress = QProgressBar()
+        self._progress.setMaximum(self._overall_total)
+        self._progress.setValue(0)
+        self._progress.setStyleSheet("""
+            QProgressBar {
+                border: 1px solid #45475a;
+                border-radius: 4px;
+                text-align: center;
+                color: #cdd6f4;
+                background-color: #1e1e2e;
+                height: 20px;
+            }
+            QProgressBar::chunk {
+                background-color: #89b4fa;
+                border-radius: 3px;
+            }
+            """)
+        bottom_layout.addWidget(self._progress)
+
+        status_row = QHBoxLayout()
+        self._status = QLabel("Starting...")
+        self._status.setStyleSheet("color: #6c7086; background: transparent;")
+        status_row.addWidget(self._status, stretch=1)
+
+        self._cancel_btn = QPushButton("Cancel")
+        self._cancel_btn.setStyleSheet("""
+            QPushButton {
+                padding: 4px 16px;
+                background-color: #45475a;
+                border: 1px solid #585b70;
+                border-radius: 4px;
+                color: #cdd6f4;
+            }
+            QPushButton:hover {
+                background-color: #f38ba8;
+                color: #1e1e2e;
+            }
+            """)
+        self._cancel_btn.clicked.connect(self._cancel)
+        status_row.addWidget(self._cancel_btn)
+
+        bottom_layout.addLayout(status_row)
+        layout.addWidget(bottom)
+
+    def _wire_signals(self) -> None:
+        self._signals = _PullSignals()
+        self._signals.log_line.connect(self._on_log_line)
+        self._signals.day_start.connect(self._on_day_start)
+        self._signals.day_skipped.connect(self._on_day_skipped)
+        self._signals.metric_done.connect(self._on_metric_done)
+        self._signals.mfa_needed.connect(self._on_mfa_needed)
+        self._signals.finished.connect(self._on_finished)
+        self._signals.error.connect(self._on_error)
+
+    # ── credential check ─────────────────────────────────────────────────
+
+    def _check_creds_and_start(self) -> None:
+        from garmin_extract._credentials import load_credentials
+
+        email, password = load_credentials()
+        if password:
+            self._email = email
+            self._password = password
+            self._start_pull()
+        else:
+            dlg = _RuntimeCredsDialog(self)
+            if dlg.exec() == QDialog.DialogCode.Accepted:
+                self._email = dlg.result_email
+                self._password = dlg.result_password
+                self._start_pull()
+            else:
+                self.reject()
+
+    # ── subprocess ────────────────────────────────────────────────────────
+
+    def _start_pull(self) -> None:
+        cmd = self._build_cmd()
+        Thread(target=self._run_pull, args=(cmd,), daemon=True).start()
+
+    def _build_cmd(self) -> list[str]:
+        if self._rebuild_only:
+            return [sys.executable, "-u", str(ROOT / "reports" / "build_garmin_csvs.py")]
+        if self._zip_path:
+            return [
+                sys.executable,
+                "-u",
+                str(ROOT / "pullers" / "garmin_import_export.py"),
+                "--zip",
+                self._zip_path,
+            ]
+        cmd = [
+            sys.executable,
+            "-u",
+            str(ROOT / "pullers" / "garmin.py"),
+            "--date",
+            self._start_date,
+            "--days",
+            str(self._days),
+        ]
+        if self._no_skip:
+            cmd.append("--no-skip")
+        return cmd
+
+    def _run_pull(self, cmd: list[str]) -> None:
+        env = os.environ.copy()
+        if self._email:
+            env["GARMIN_EMAIL"] = self._email
+        if self._password:
+            env["GARMIN_PASSWORD"] = self._password
+
+        try:
+            proc = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                cwd=str(ROOT),
+                env=env,
+            )
+            self._proc = proc
+            assert proc.stdout is not None
+            for raw_line in iter(proc.stdout.readline, ""):
+                line = raw_line.rstrip("\n")
+                self._signals.log_line.emit(line)
+                self._parse_line(line)
+            proc.wait()
+            self._proc = None
+            self._signals.finished.emit(proc.returncode)
+        except Exception as exc:
+            self._proc = None
+            self._signals.error.emit(str(exc))
+
+    def _parse_line(self, line: str) -> None:
+        """Parse subprocess output and emit appropriate signals."""
+        stripped = line.strip()
+
+        # "[2025-04-06] Pulling N metrics..."
+        if stripped.startswith("[") and "] Pulling " in stripped and "metrics" in stripped:
+            try:
+                date_str = stripped[1 : stripped.index("]")]
+                parts = stripped.split()
+                idx = next((i for i, p in enumerate(parts) if p == "Pulling"), -1)
+                n = int(parts[idx + 1]) if idx >= 0 else 0
+                self._signals.day_start.emit(date_str, n)
+            except (ValueError, IndexError):
+                pass
+            return
+
+        # "[2025-04-06] Already pulled — skipping"
+        if "Already pulled" in stripped and "skipping" in stripped:
+            try:
+                date_str = stripped[1 : stripped.index("]")]
+                self._signals.day_skipped.emit(date_str)
+            except ValueError:
+                pass
+            return
+
+        # "✓/✗  metric_name"
+        if stripped.startswith("\u2713") or stripped.startswith("\u2717"):
+            parts = stripped.split()
+            if parts:
+                self._signals.metric_done.emit(parts[-1], stripped.startswith("\u2713"))
+            return
+
+        # MFA prompt
+        if "Run: echo YOUR_CODE" in stripped:
+            self._signals.mfa_needed.emit()
+
+    # ── day state init ───────────────────────────────────────────────────
+
+    def _init_day_states(self) -> list[_DayState]:
+        states: list[_DayState] = []
+        try:
+            start = date.fromisoformat(self._start_date)
+            for i in range(self._days):
+                states.append(_DayState((start + timedelta(days=i)).isoformat()))
+        except ValueError:
+            pass
+        return states
+
+    def _initial_panel_body(self) -> str:
+        if self._mode == "day":
+            return self._render_day_list()
+        if self._mode == "metric":
+            return "Waiting for first metric..."
+        return "Starting..."
+
+    # ── signal handlers (main thread) ────────────────────────────────────
+
+    def _on_log_line(self, line: str) -> None:
+        self._log.append(line)
+
+    def _on_day_start(self, date_str: str, n_metrics: int) -> None:
+        if self._mode == "day":
+            idx = next(
+                (i for i, s in enumerate(self._day_states) if s.date_str == date_str),
+                -1,
+            )
+            if idx == -1:
+                self._day_states.append(_DayState(date_str))
+                idx = len(self._day_states) - 1
+            self._current_day_index = idx
+            self._day_states[idx].status = "active"
+            self._day_states[idx].total = n_metrics
+
+            if self._metrics_per_day == 0 and n_metrics > 0:
+                self._metrics_per_day = n_metrics
+                self._overall_total = self._days * n_metrics
+                self._progress.setMaximum(self._overall_total)
+
+            self._refresh_panel()
+            self._status.setText(f"Day {idx + 1} of {self._days}  \u00b7  {date_str}")
+
+        elif self._mode == "metric":
+            self._day_total = n_metrics
+            self._day_done = 0
+            self._live_metrics = []
+            if n_metrics > 0:
+                self._progress.setMaximum(n_metrics)
+            self._subheader.setText(date_str)
+            self._refresh_panel()
+            self._status.setText(f"Pulling {date_str}...")
+
+    def _on_day_skipped(self, date_str: str) -> None:
+        if self._mode == "day":
+            idx = next(
+                (i for i, s in enumerate(self._day_states) if s.date_str == date_str),
+                -1,
+            )
+            if idx >= 0:
+                self._day_states[idx].status = "skipped"
+                advance = self._metrics_per_day if self._metrics_per_day else 1
+                self._overall_done += advance
+                self._progress.setValue(self._overall_done)
+                self._refresh_panel()
+                self._status.setText(f"Skipped {date_str}  (already pulled)")
+
+    def _on_metric_done(self, name: str, is_ok: bool) -> None:
+        if self._mode == "metric":
+            self._live_metrics.append((name, "done" if is_ok else "fail"))
+            self._day_done += 1
+            self._progress.setValue(self._day_done)
+            self._refresh_panel()
+            self._status.setText(f"{self._day_done} / {self._day_total or '?'} metrics")
+
+        elif self._mode == "day" and self._current_day_index >= 0:
+            ds = self._day_states[self._current_day_index]
+            if is_ok:
+                ds.done += 1
+            else:
+                ds.failed += 1
+
+            tally = ds.done + ds.failed
+            if ds.total == 0 or tally <= ds.total:
+                self._overall_done += 1
+                self._progress.setValue(self._overall_done)
+
+            if ds.total > 0 and tally >= ds.total:
+                ds.status = "done"
+
+            self._refresh_panel()
+            self._status.setText(
+                f"Day {self._current_day_index + 1} of {self._days}"
+                f"  \u00b7  {min(tally, ds.total) if ds.total else tally}"
+                f"/{ds.total or '?'} metrics"
+            )
+
+    def _on_mfa_needed(self) -> None:
+        if not self._mfa_shown:
+            self._mfa_shown = True
+            _MfaDialog(self).exec()
+
+    def _on_finished(self, returncode: int) -> None:
+        if self._mode == "simple":
+            self._progress.setMaximum(1)
+            self._progress.setValue(1)
+            if returncode == 0:
+                self._metric_list.setText("\u2713 Complete")
+            else:
+                self._metric_list.setText("\u2717 Failed")
+
+        if returncode == 0:
+            self._status.setText("Complete \u2713")
+            self._log.append("\nDone.")
+        else:
+            self._status.setText(f"Finished with errors (exit {returncode})")
+            self._log.append(f"\nProcess exited with code {returncode}.")
+
+        self._cancel_btn.setText("Close")
+        self._cancel_btn.clicked.disconnect()
+        self._cancel_btn.clicked.connect(self.accept)
+
+    def _on_error(self, msg: str) -> None:
+        self._log.append(f"\nError: {msg}")
+        self._status.setText("Error")
+        self._cancel_btn.setText("Close")
+        self._cancel_btn.clicked.disconnect()
+        self._cancel_btn.clicked.connect(self.accept)
+
+    # ── panel rendering ──────────────────────────────────────────────────
+
+    def _refresh_panel(self) -> None:
+        if self._mode == "day":
+            self._metric_list.setText(self._render_day_list())
+        elif self._mode == "metric":
+            self._metric_list.setText(self._render_metric_list())
+
+    def _render_day_list(self) -> str:
+        lines: list[str] = []
+        for ds in self._day_states:
+            if ds.status == "done":
+                tally = min(ds.done + ds.failed, ds.total) if ds.total else ds.done + ds.failed
+                count = f"({tally}/{ds.total})" if ds.total else ""
+                failed = f"  {ds.failed} failed" if ds.failed else ""
+                lines.append(f"\u2713 {ds.date_str}  {count}{failed}")
+            elif ds.status == "active":
+                count = f"{ds.done + ds.failed}/{ds.total}" if ds.total else "\u2026"
+                lines.append(f"\u25cf {ds.date_str}  ({count})")
+            elif ds.status == "skipped":
+                lines.append(f"\u21b7 {ds.date_str}  (skipped)")
+            else:
+                lines.append(f"\u25cb  {ds.date_str}")
+        return "\n".join(lines)
+
+    def _render_metric_list(self) -> str:
+        if not self._live_metrics:
+            return "Waiting for first metric..."
+        lines: list[str] = []
+        for name, state in self._live_metrics:
+            icon = "\u2713" if state == "done" else "\u2717"
+            lines.append(f"{icon} {name}")
+        return "\n".join(lines)
+
+    # ── cancel ───────────────────────────────────────────────────────────
+
+    def _cancel(self) -> None:
+        if self._proc is not None:
+            try:
+                self._proc.terminate()
+            except Exception:
+                pass
+        self.reject()
+
+    def closeEvent(self, event: object) -> None:  # noqa: N802
+        if self._proc is not None:
+            try:
+                self._proc.terminate()
+            except Exception:
+                pass
+        super().closeEvent(event)

--- a/garmin_extract/gui/screens/setup.py
+++ b/garmin_extract/gui/screens/setup.py
@@ -1,0 +1,617 @@
+"""Initial Setup page — prerequisite checks, credentials, Gmail OAuth."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from threading import Thread
+
+from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtWidgets import (
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QProgressBar,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+ROOT = Path(__file__).parent.parent.parent.parent
+GMAIL_CREDS_FILE = ROOT / "google_credentials.json"
+GMAIL_TOKEN_FILE = ROOT / ".google_token.json"
+GMAIL_AUTH_CODE_FILE = ROOT / ".gmail_auth_code"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _check_python() -> tuple[bool, str]:
+    v = sys.version_info
+    return v >= (3, 12), f"Python {v.major}.{v.minor}.{v.micro}"
+
+
+def _check_chrome() -> tuple[bool, str]:
+    from garmin_extract.menu import _find_chrome
+
+    found, version = _find_chrome()
+    return found, version or "Not found"
+
+
+def _check_packages() -> tuple[bool, str]:
+    from garmin_extract.menu import _missing_packages
+
+    missing = _missing_packages()
+    if not missing:
+        return True, "All installed"
+    return False, f"Missing: {', '.join(missing)}"
+
+
+def _check_credentials() -> tuple[bool, str]:
+    from garmin_extract._credentials import check_credentials
+
+    return check_credentials()
+
+
+def _check_gmail() -> tuple[bool, str]:
+    if not GMAIL_CREDS_FILE.exists():
+        return False, "google_credentials.json missing"
+    if not GMAIL_TOKEN_FILE.exists():
+        return False, "Credentials found — not yet authorized"
+    return True, "Authorized"
+
+
+# ── Signals bridge (thread → UI) ────────────────────────────────────────────
+
+
+class _StatusSignals(QObject):
+    """Signals emitted from background threads to update the UI."""
+
+    prereq_done = Signal(bool, str)  # (all_ok, summary)
+    creds_done = Signal(bool, str)  # (ok, detail)
+    gmail_done = Signal(bool, str)  # (ok, detail)
+    all_done = Signal()
+
+
+# ── Status card widget ───────────────────────────────────────────────────────
+
+
+class _StatusCard(QFrame):
+    """A clickable card showing a section name, status icon, and detail text."""
+
+    def __init__(self, title: str, subtitle: str, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("status-card")
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.setStyleSheet("""
+            QFrame#status-card {
+                background-color: #313244;
+                border: 1px solid #45475a;
+                border-radius: 8px;
+                padding: 16px;
+            }
+            QFrame#status-card:hover {
+                border-color: #89b4fa;
+            }
+            """)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(16, 12, 16, 12)
+
+        # Left: icon + text
+        left = QVBoxLayout()
+        left.setSpacing(4)
+
+        self._title = QLabel(title)
+        self._title.setStyleSheet("font-size: 16px; font-weight: bold; background: transparent;")
+        left.addWidget(self._title)
+
+        self._subtitle = QLabel(subtitle)
+        self._subtitle.setStyleSheet("font-size: 13px; color: #6c7086; background: transparent;")
+        left.addWidget(self._subtitle)
+
+        self._detail = QLabel("Checking…")
+        self._detail.setStyleSheet("font-size: 13px; color: #6c7086; background: transparent;")
+        left.addWidget(self._detail)
+
+        layout.addLayout(left, stretch=1)
+
+        # Right: status icon
+        self._icon = QLabel("○")
+        self._icon.setStyleSheet("font-size: 22px; color: #6c7086; background: transparent;")
+        self._icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._icon.setFixedWidth(40)
+        layout.addWidget(self._icon)
+
+        self._callback: object = None
+
+    def set_status(self, ok: bool, detail: str) -> None:
+        if ok:
+            self._icon.setText("✓")
+            self._icon.setStyleSheet("font-size: 22px; color: #a6e3a1; background: transparent;")
+        else:
+            self._icon.setText("✗")
+            self._icon.setStyleSheet("font-size: 22px; color: #f38ba8; background: transparent;")
+        # Strip Rich markup for GUI display
+        import re
+
+        clean = re.sub(r"\[/?[^\]]*\]", "", detail)
+        self._detail.setText(clean)
+
+    def on_click(self, callback: object) -> None:
+        self._callback = callback
+
+    def mousePressEvent(self, event: object) -> None:  # noqa: N802
+        if self._callback and callable(self._callback):
+            self._callback()
+
+
+# ── Prerequisites dialog ─────────────────────────────────────────────────────
+
+
+class PrereqDialog(QDialog):
+    """Modal dialog that runs prerequisite checks with live output."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Prerequisites")
+        self.setMinimumSize(600, 400)
+        self.resize(700, 500)
+
+        layout = QVBoxLayout(self)
+
+        self._log = QTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setStyleSheet(
+            "background-color: #1e1e2e; color: #cdd6f4; font-family: monospace;"
+            " font-size: 13px; border: 1px solid #45475a; border-radius: 4px;"
+        )
+        layout.addWidget(self._log)
+
+        self._progress = QProgressBar()
+        self._progress.setMaximum(3)
+        self._progress.setValue(0)
+        layout.addWidget(self._progress)
+
+        self._status = QLabel("Running checks…")
+        self._status.setStyleSheet("color: #6c7086;")
+        self._status.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self._status)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+        self._close_btn = QPushButton("Close")
+        self._close_btn.setEnabled(False)
+        self._close_btn.clicked.connect(self.accept)
+        btn_layout.addWidget(self._close_btn)
+        layout.addLayout(btn_layout)
+
+        self._signals = _CheckSignals()
+        self._signals.log_line.connect(self._append_log)
+        self._signals.progress.connect(self._progress.setValue)
+        self._signals.finished.connect(self._on_finished)
+
+        Thread(target=self._run_checks, daemon=True).start()
+
+    def _run_checks(self) -> None:
+        checks = [
+            ("Python 3.12+", _check_python),
+            ("Google Chrome", _check_chrome),
+            ("Python packages", _check_packages),
+        ]
+        failed: list[str] = []
+        for i, (name, fn) in enumerate(checks):
+            ok, detail = fn()
+            icon = "✓" if ok else "✗"
+            self._signals.log_line.emit(f"  {icon}  {name}: {detail}")
+            if not ok:
+                failed.append(name)
+            self._signals.progress.emit(i + 1)
+
+        if failed:
+            self._signals.finished.emit(f"Issues found: {', '.join(failed)}")
+        else:
+            self._signals.finished.emit("All checks passed ✓")
+
+    def _append_log(self, text: str) -> None:
+        self._log.append(text)
+
+    def _on_finished(self, summary: str) -> None:
+        self._status.setText(summary)
+        self._close_btn.setEnabled(True)
+        self._progress.hide()
+
+
+class _CheckSignals(QObject):
+    log_line = Signal(str)
+    progress = Signal(int)
+    finished = Signal(str)
+
+
+# ── Credentials dialog ───────────────────────────────────────────────────────
+
+
+class CredentialsDialog(QDialog):
+    """Modal dialog for entering Garmin Connect credentials."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Garmin Connect Credentials")
+        self.setMinimumWidth(480)
+        self.setModal(True)
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(12)
+
+        # Keyring status
+        self._mode_label = QLabel("Detecting keyring…")
+        self._mode_label.setStyleSheet("color: #6c7086; font-size: 13px;")
+        layout.addWidget(self._mode_label)
+
+        # Warning panel (hidden by default)
+        self._warning = QLabel()
+        self._warning.setWordWrap(True)
+        self._warning.setStyleSheet(
+            "background-color: #45475a; color: #f38ba8; border: 1px solid #f38ba8;"
+            " border-radius: 6px; padding: 12px; font-size: 13px;"
+        )
+        self._warning.hide()
+        layout.addWidget(self._warning)
+
+        # Email
+        layout.addWidget(QLabel("Email"))
+        self._email = QLineEdit()
+        self._email.setPlaceholderText("you@example.com")
+        layout.addWidget(self._email)
+
+        # Password
+        layout.addWidget(QLabel("Password"))
+        self._password = QLineEdit()
+        self._password.setEchoMode(QLineEdit.EchoMode.Password)
+        self._password.setPlaceholderText("Garmin Connect password")
+        layout.addWidget(self._password)
+
+        # Feedback
+        self._error = QLabel()
+        self._error.setStyleSheet("color: #f38ba8;")
+        self._error.hide()
+        layout.addWidget(self._error)
+
+        self._success = QLabel()
+        self._success.setStyleSheet("color: #a6e3a1;")
+        self._success.hide()
+        layout.addWidget(self._success)
+
+        # Buttons
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        btn_layout.addWidget(cancel_btn)
+        self._save_btn = QPushButton("Save")
+        self._save_btn.clicked.connect(self._save)
+        btn_layout.addWidget(self._save_btn)
+        layout.addLayout(btn_layout)
+
+        self._keyring_available: bool | None = None
+        Thread(target=self._detect_keyring, daemon=True).start()
+        self._load_existing()
+
+    def _load_existing(self) -> None:
+        try:
+            from garmin_extract._credentials import load_credentials
+
+            email, _ = load_credentials()
+            if email:
+                self._email.setText(email)
+                self._password.setFocus()
+            else:
+                self._email.setFocus()
+        except Exception:
+            self._email.setFocus()
+
+    def _detect_keyring(self) -> None:
+        from garmin_extract._credentials import detect_keyring
+
+        ok, detail = detect_keyring()
+        # Use QMetaObject.invokeMethod for thread safety — but simpler
+        # to use a signal. For brevity, just set and update in main thread.
+        self._keyring_available = ok
+        self._keyring_detail = detail
+
+    def showEvent(self, event: object) -> None:  # noqa: N802
+        super().showEvent(event)
+        # Poll for keyring detection result (runs nearly instantly)
+        from PySide6.QtCore import QTimer
+
+        def _apply() -> None:
+            if self._keyring_available is None:
+                QTimer.singleShot(50, _apply)
+                return
+            if self._keyring_available:
+                self._mode_label.setText(f"● Keyring: {self._keyring_detail}")
+                self._mode_label.setStyleSheet("color: #a6e3a1; font-size: 13px;")
+            else:
+                self._mode_label.setText(
+                    "⚠ No secure keyring — credentials will be saved to .env (plaintext)"
+                )
+                self._mode_label.setStyleSheet("color: #f9e2af; font-size: 13px;")
+                self._warning.setText(
+                    "⚠ PLAINTEXT WARNING\n\n"
+                    "Saving will write your password to a plain-text file on disk.\n"
+                    "Anyone with read access to your filesystem can see it."
+                )
+                self._warning.show()
+
+        QTimer.singleShot(50, _apply)
+
+    def _save(self) -> None:
+        from garmin_extract._credentials import save_to_env, save_to_keyring
+
+        email = self._email.text().strip()
+        password = self._password.text().strip()
+
+        self._error.hide()
+        self._success.hide()
+
+        if not email:
+            self._error.setText("Email is required.")
+            self._error.show()
+            self._email.setFocus()
+            return
+        if not password:
+            self._error.setText("Password is required.")
+            self._error.show()
+            self._password.setFocus()
+            return
+
+        if self._keyring_available:
+            ok, detail = save_to_keyring(email, password)
+            if ok:
+                self._success.setText(f"✓ Saved to keyring — {email}")
+                self._success.show()
+            else:
+                self._error.setText(f"Keyring save failed: {detail}")
+                self._error.show()
+                return
+        else:
+            save_to_env(email, password)
+            self._success.setText(f"✓ Saved to .env — {email}")
+            self._success.show()
+
+        self._save_btn.setEnabled(False)
+        from PySide6.QtCore import QTimer
+
+        QTimer.singleShot(1200, self.accept)
+
+
+# ── Gmail OAuth dialog ───────────────────────────────────────────────────────
+
+
+class GmailOAuthDialog(QDialog):
+    """Modal dialog for Gmail OAuth authorization flow."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Gmail OAuth Setup")
+        self.setMinimumSize(650, 450)
+        self.setModal(True)
+
+        layout = QVBoxLayout(self)
+
+        self._log = QTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setStyleSheet(
+            "background-color: #1e1e2e; color: #cdd6f4; font-family: monospace;"
+            " font-size: 13px; border: 1px solid #45475a; border-radius: 4px;"
+        )
+        layout.addWidget(self._log)
+
+        # Code input area (hidden until needed)
+        self._code_frame = QFrame()
+        self._code_frame.hide()
+        code_layout = QVBoxLayout(self._code_frame)
+        code_layout.setContentsMargins(0, 8, 0, 0)
+        code_layout.addWidget(QLabel("Paste the authorization code below:"))
+        self._code_input = QLineEdit()
+        self._code_input.setPlaceholderText("Paste code here")
+        self._code_input.returnPressed.connect(self._submit_code)
+        code_layout.addWidget(self._code_input)
+        layout.addWidget(self._code_frame)
+
+        self._status = QLabel()
+        self._status.setStyleSheet("color: #6c7086;")
+        self._status.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self._status)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch()
+        self._close_btn = QPushButton("Close")
+        self._close_btn.clicked.connect(self.accept)
+        btn_layout.addWidget(self._close_btn)
+        layout.addLayout(btn_layout)
+
+        self._auth_url = ""
+        self._signals = _GmailSignals()
+        self._signals.log_line.connect(self._append_log)
+        self._signals.show_code_input.connect(self._show_code_input)
+        self._signals.finished.connect(self._on_finished)
+
+        self._start_flow()
+
+    def _start_flow(self) -> None:
+        if not GMAIL_CREDS_FILE.exists():
+            self._log.append(
+                "google_credentials.json not found.\n\n"
+                "To create it:\n"
+                "  1. Go to https://console.cloud.google.com\n"
+                "  2. Create a project\n"
+                "  3. Enable the Gmail API\n"
+                "  4. Credentials → Create → OAuth 2.0 Client ID → Desktop app\n"
+                "  5. Download JSON → save as google_credentials.json\n"
+                "     in the project root directory\n\n"
+                "Then come back here to complete authorization."
+            )
+            self._status.setText("google_credentials.json required")
+            return
+
+        if GMAIL_TOKEN_FILE.exists():
+            self._log.append(
+                "✓  Gmail MFA is already authorized.\n\n"
+                "Token file found: .google_token.json\n\n"
+                "To re-authorize, delete .google_token.json and run this again."
+            )
+            self._status.setText("Already authorized ✓")
+            return
+
+        self._status.setText("Running authorization flow…")
+        Thread(target=self._do_auth, daemon=True).start()
+
+    def _do_auth(self) -> None:
+        import subprocess
+
+        try:
+            proc = subprocess.Popen(
+                [sys.executable, "-u", str(ROOT / "scripts" / "setup_gmail_auth.py")],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                cwd=str(ROOT),
+            )
+            assert proc.stdout is not None
+            code_shown = False
+            for raw_line in iter(proc.stdout.readline, ""):
+                line = raw_line.rstrip("\n")
+                self._signals.log_line.emit(line)
+
+                if line.startswith("https://") and not code_shown:
+                    self._auth_url = line.strip()
+
+                if "Waiting up to" in line and not code_shown:
+                    code_shown = True
+                    self._signals.show_code_input.emit(self._auth_url)
+
+            proc.wait()
+            if proc.returncode == 0:
+                self._signals.finished.emit("Gmail MFA authorized ✓")
+            else:
+                self._signals.finished.emit("Authorization did not complete")
+        except Exception as exc:
+            self._signals.finished.emit(f"Error: {exc}")
+
+    def _append_log(self, text: str) -> None:
+        self._log.append(text)
+
+    def _show_code_input(self, auth_url: str) -> None:
+        self._status.setText("Open the URL above in any browser, then paste the code below")
+        self._code_frame.show()
+        self._code_input.setFocus()
+
+    def _submit_code(self) -> None:
+        code = self._code_input.text().strip()
+        if not code:
+            return
+        GMAIL_AUTH_CODE_FILE.write_text(code + "\n")
+        self._code_frame.hide()
+        self._status.setText("Code submitted — waiting for confirmation…")
+
+    def _on_finished(self, summary: str) -> None:
+        self._status.setText(summary)
+        self._code_frame.hide()
+
+
+class _GmailSignals(QObject):
+    log_line = Signal(str)
+    show_code_input = Signal(str)
+    finished = Signal(str)
+
+
+# ── Setup page (main content widget) ────────────────────────────────────────
+
+
+class SetupPage(QWidget):
+    """The Initial Setup page shown in the main window's stacked widget."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(40, 32, 40, 32)
+        layout.setSpacing(8)
+
+        heading = QLabel("Initial Setup")
+        heading.setObjectName("heading")
+        layout.addWidget(heading)
+
+        sub = QLabel("Configure credentials and prerequisites")
+        sub.setObjectName("subheading")
+        layout.addWidget(sub)
+
+        layout.addSpacing(16)
+
+        # ── Prerequisite card ─────────────────────────
+        self._prereq_card = _StatusCard("Prerequisites", "Python, Chrome, packages")
+        self._prereq_card.on_click(self._open_prereqs)
+        layout.addWidget(self._prereq_card)
+
+        layout.addSpacing(4)
+
+        # ── Credentials card ──────────────────────────
+        self._creds_card = _StatusCard("Garmin Credentials", "Email and password")
+        self._creds_card.on_click(self._open_credentials)
+        layout.addWidget(self._creds_card)
+
+        layout.addSpacing(4)
+
+        # ── Gmail OAuth card ──────────────────────────
+        self._gmail_card = _StatusCard("Gmail OAuth", "Automatic MFA + Drive/Sheets (optional)")
+        self._gmail_card.on_click(self._open_gmail)
+        layout.addWidget(self._gmail_card)
+
+        layout.addStretch()
+
+        # Run initial status checks
+        self._signals = _StatusSignals()
+        self._signals.prereq_done.connect(self._prereq_card.set_status)
+        self._signals.creds_done.connect(self._creds_card.set_status)
+        self._signals.gmail_done.connect(self._gmail_card.set_status)
+        self.refresh_status()
+
+    def refresh_status(self) -> None:
+        Thread(target=self._check_all, daemon=True).start()
+
+    def _check_all(self) -> None:
+        py_ok, _ = _check_python()
+        chrome_ok, _ = _check_chrome()
+        pkg_ok, _ = _check_packages()
+        all_ok = py_ok and chrome_ok and pkg_ok
+
+        parts = []
+        for ok, name in [(py_ok, "Python"), (chrome_ok, "Chrome"), (pkg_ok, "Packages")]:
+            parts.append(f"{'✓' if ok else '✗'} {name}")
+        self._signals.prereq_done.emit(all_ok, "  ".join(parts))
+
+        creds_ok, creds_str = _check_credentials()
+        self._signals.creds_done.emit(creds_ok, creds_str)
+
+        gmail_ok, gmail_str = _check_gmail()
+        self._signals.gmail_done.emit(gmail_ok, gmail_str)
+
+    def _open_prereqs(self) -> None:
+        dlg = PrereqDialog(self)
+        dlg.exec()
+        self.refresh_status()
+
+    def _open_credentials(self) -> None:
+        dlg = CredentialsDialog(self)
+        dlg.exec()
+        self.refresh_status()
+
+    def _open_gmail(self) -> None:
+        dlg = GmailOAuthDialog(self)
+        dlg.exec()
+        self.refresh_status()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "garmin-extract"
-version = "1.3.1"
+version = "1.4.0"
 description = "Automated Garmin Connect data pipeline using browser automation"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.3.0"
+version = "1.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },
@@ -434,6 +434,11 @@ dependencies = [
     { name = "rich" },
     { name = "seleniumbase" },
     { name = "textual" },
+]
+
+[package.optional-dependencies]
+gui = [
+    { name = "pyside6" },
 ]
 
 [package.dev-dependencies]
@@ -451,6 +456,7 @@ requires-dist = [
     { name = "google-auth", specifier = ">=2.0.0" },
     { name = "google-auth-oauthlib", specifier = ">=1.0.0" },
     { name = "keyring", specifier = ">=24.0.0" },
+    { name = "pyside6", marker = "extra == 'gui'", specifier = ">=6.6.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "requests-oauthlib", specifier = ">=1.3.0" },
@@ -458,6 +464,7 @@ requires-dist = [
     { name = "seleniumbase", specifier = ">=4.0.0" },
     { name = "textual", specifier = ">=0.50.0" },
 ]
+provides-extras = ["gui"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1190,6 +1197,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/f0/cb456ac4f1a73723d5b866933b7986f02bacea27516629c00f8e7da94c2d/pyscreeze-1.0.1.tar.gz", hash = "sha256:cf1662710f1b46aa5ff229ee23f367da9e20af4a78e6e365bee973cad0ead4be", size = 27826, upload-time = "2024-08-20T23:03:07.291Z" }
 
 [[package]]
+name = "pyside6"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-addons" },
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/95/f3f5a2799163b6658126d78a85bc1dec9eda88c75c26780556b26071a1d8/pyside6-6.11.0-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:1f2735dc4f2bd4ec452ae50502c8a22128bba0aced35358a2bbc58384b820c6f", size = 571544, upload-time = "2026-03-23T12:47:20.263Z" },
+    { url = "https://files.pythonhosted.org/packages/da/89/9a1f521051714e6694ebbe2b979ded279845ec8e25cb309ca3960158d74f/pyside6-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c642e2d25704ca746fd37f56feacf25c5aecc4cd40bef23d18eec81f87d9dc00", size = 571725, upload-time = "2026-03-23T12:47:21.727Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3d/f779d8bba00fcde31a7d7fb6b59347a70773c9cc8135592dea9972579877/pyside6-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:267b344c73580ac938ca63c611881fb42a3922ebfe043e271005f4f06c372c4e", size = 571722, upload-time = "2026-03-23T12:47:22.761Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/98/150e01a026df3e9697310236821fa825319bb4b9d6137539cb25a3032968/pyside6-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:9092cb002ca43c64006afb2e0d0f6f51aef17aa737c33a45e502326a081ddcbc", size = 577988, upload-time = "2026-03-23T12:47:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e7/55960f7c6b41d058e95cb4af02652c46c48702c506c8bbf12e99550e1fb3/pyside6-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:b15f39acc2b8f46251a630acad0d97f9a0a0461f2baffcd66d7adfada8eb641e", size = 561372, upload-time = "2026-03-23T12:47:25.073Z" },
+]
+
+[[package]]
+name = "pyside6-addons"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyside6-essentials" },
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/df/241f311c61a46b7b1195927da77b2537692ee3442aa9ccd87981164ff78d/pyside6_addons-6.11.0-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:d5eaa4643302e3a0fa94c5766234bee4073d7d5ab9c2b7fd222692a176faf182", size = 331554157, upload-time = "2026-03-23T12:40:40.497Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b9/e81172835ccc9d8b9792cc6bf7524a252a0db9a76ddd693de230402697f9/pyside6_addons-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ac6fe3d4ef4497dde3efc5e896b0acd53ff6c93be4bf485f045690f919419f35", size = 174948482, upload-time = "2026-03-23T12:41:05.379Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/426d9333782bf65ab2a20257d6b4b3af9b8d5d7a710da719865fab49d492/pyside6_addons-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:8ffb40222456078930816ebcac2f2511716d2acbc11716dd5acc5c365179a753", size = 170430798, upload-time = "2026-03-23T12:41:38.134Z" },
+    { url = "https://files.pythonhosted.org/packages/35/9a/46d271fedfabad8c6dce2ebb69bb593745487ed33753a56a47c3ba4fdb1c/pyside6_addons-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:413e6121c24f5ffdce376298059eddecff74aa6d638e94e0f6015b33d29b889e", size = 168723088, upload-time = "2026-03-23T12:42:00.668Z" },
+    { url = "https://files.pythonhosted.org/packages/16/cd/1b28264f7dc9a642da2e4e7c02f67418d0949eb7ce329ae20869703c2630/pyside6_addons-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:aaaee83385977a0fe134b2f4fbfb92b45a880d5b656e4d90a708eef10b1b6de8", size = 35698324, upload-time = "2026-03-23T12:42:13.748Z" },
+]
+
+[[package]]
+name = "pyside6-essentials"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "shiboken6" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/00/8a8583d3429c737cc20e61a43eba8ab1ec13ddb101e99802c2ffeedf3b41/pyside6_essentials-6.11.0-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:85d6ca87ef35fa6565d385ede72ae48420dd3f63113929d10fc800f6b0360e01", size = 108085251, upload-time = "2026-03-23T12:42:52.872Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a9/07c9e5c014b871c1b19caf8f994bcd50b345559b81f81671217b49559b67/pyside6_essentials-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:dc20e7afd5fc6fe51297db91cef997ce60844be578f7a49fc61b7ab9657a8849", size = 78316055, upload-time = "2026-03-23T12:43:04.19Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/35/f06b1b641d7600ec46374c16cd37c66fa4a22870326b4eb073a95471035f/pyside6_essentials-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:4854cb0a1b061e7a576d8fb7bb7cf9f49540d558b1acb7df0742a7afefe61e4e", size = 77380821, upload-time = "2026-03-23T12:43:24.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/37/ba95c6262836d2b286b4e05a9d16a5e870995d5d2503ac6adc6312208049/pyside6_essentials-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:3b3362882ad9389357a80504e600180006a957731fec05786fced7b038461fdf", size = 75793322, upload-time = "2026-03-23T12:43:35.575Z" },
+    { url = "https://files.pythonhosted.org/packages/53/27/d17f25e45820e633a70e6109b35991eda09a5e8000c2a306f0ab7538d48c/pyside6_essentials-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:81ca603dbf21bc39f89bb42db215c25ebe0c879a1a4c387625c321d2730ec187", size = 56337457, upload-time = "2026-03-23T12:43:43.573Z" },
+]
+
+[[package]]
 name = "pysocks"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1592,6 +1647,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "shiboken6"
+version = "6.11.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/1d/b56b7b694fbc871496435488d1f41c5068de546334850d722756511cef65/shiboken6-6.11.0-cp310-abi3-macosx_13_0_universal2.whl", hash = "sha256:d88e8a1eb705f2b9ad21db08a61ae1dc0c773e5cd86a069de0754c4cf1f9b43b", size = 476085, upload-time = "2026-03-23T12:47:05.724Z" },
+    { url = "https://files.pythonhosted.org/packages/65/cb/4bb0c76011166230daa7c0074aeb3fdb3935c83ac1fef3789b85fcd1a8fc/shiboken6-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:ad54e64f8192ddbdff0c54ac82b89edcd62ed623f502ea21c960541d19514053", size = 271055, upload-time = "2026-03-23T12:47:07.349Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/96/771a6e2b530f725303d16d78a321fa4876b98b4f3615c9851880df8c1a43/shiboken6-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a10dc7718104ea2dc15d5b0b96909b77162ce1c76fcc6968e6df692b947a00e9", size = 267456, upload-time = "2026-03-23T12:47:08.689Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f7/44c0c42c3f5f29dec457fd46ea0552174bcb8aa75becf03bbd90308ba07b/shiboken6-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:483ff78a73c7b3189ca924abc694318084f078bcfeaffa68e32024ff2d025ee1", size = 1222132, upload-time = "2026-03-23T12:47:10.143Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/99/6e5ee21db2d6af84bbbd7d871d441dafeb069c6de5667b1aa49891a77c66/shiboken6-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:3bd76cf56105ab2d62ecaff630366f11264f69b88d488f10f048da9a065781f4", size = 1783186, upload-time = "2026-03-23T12:47:11.832Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First Windows release with a native PySide6 GUI. All three sidebar pages are fully functional; remaining roadmap items (#31 Task Scheduler, #32 PyInstaller) will land in follow-ups.

## What's new

### Windows GUI (PySide6)
- **Main window** with left sidebar navigation + stacked content area (#26)
- **Initial Setup** page: 3 status cards — Prerequisites, Garmin Credentials, Gmail OAuth — with live background checks (#27)
- **Pull Data** page: all 8 options (Fetch New, Yesterday, Last 7/30, Custom, Full history, Import zip, Rebuild CSVs) (#28)
- **Pull Progress** dialog: split log + metrics panel, MFA modal, runtime credentials modal, cancel button (#29)
- **Automation** page: Gmail MFA status card, Drive/Sheets action buttons, Scheduled Pulls card (placeholder for #31) (#30)
- Catppuccin Mocha-inspired dark theme matching the Linux TUI aesthetic
- Platform routing in cli.py: Windows + PySide6 → GUI, else → Textual TUI, fallback → print menu
- `--no-gui` flag to bypass the GUI on Windows

### Linux TUI fixes
- **Scrub plaintext credentials from .env after successful keyring save** (#35) — prevents plaintext passwords lingering after migrating to keyring

## Installation

### Linux / macOS (unchanged)
```bash
uv pip install -e .
uv run python -m garmin_extract
```

### Windows
```powershell
pip install -e ".[gui]"
python -m garmin_extract
```

## Test plan
- [x] Linux TUI: all existing functionality unchanged
- [x] Windows GUI: main window launches with dark theme
- [x] Sidebar navigation swaps content pages correctly
- [x] All dialogs construct correctly (verified via offscreen renderer)
- [ ] Windows: full end-to-end pull via the GUI
- [ ] Windows: credentials saved to Credential Manager (keyring backend)
- [ ] Windows: MFA modal appears when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)