### PR TITLE
feat(windows): PyInstaller + GitHub Actions Windows build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,81 @@
+name: Build Windows executable
+
+on:
+  # Build and attach to release when a version tag is pushed
+  push:
+    tags:
+      - "v*.*.*"
+  # Allow manual triggering for testing or retroactive builds
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to attach the build to (e.g. v1.4.0)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write  # needed for uploading release assets
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[gui]"
+          pip install pyinstaller
+
+      - name: Build with PyInstaller
+        shell: pwsh
+        run: pyinstaller garmin-extract-windows.spec --noconfirm
+
+      - name: Determine version
+        id: version
+        shell: pwsh
+        run: |
+          if ("${{ github.event_name }}" -eq "push") {
+            $tag = "${{ github.ref_name }}"
+          } else {
+            $tag = "${{ inputs.tag }}"
+            if ([string]::IsNullOrWhiteSpace($tag)) {
+              $tag = "dev-$(git rev-parse --short HEAD)"
+            }
+          }
+          echo "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          echo "Tag: $tag"
+
+      - name: Zip the onedir build
+        shell: pwsh
+        run: |
+          $zipName = "garmin-extract-windows-${{ steps.version.outputs.tag }}.zip"
+          Compress-Archive -Path "dist\garmin-extract\*" -DestinationPath $zipName -Force
+          echo "ZIP_NAME=$zipName" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "Created: $zipName"
+
+      - name: Upload zip as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: garmin-extract-windows-${{ steps.version.outputs.tag }}
+          path: ${{ env.ZIP_NAME }}
+          retention-days: 30
+
+      - name: Attach to GitHub Release
+        # Only attach when triggered by a tag push, or when a tag was explicitly provided
+        if: github.event_name == 'push' || inputs.tag != ''
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tag = "${{ steps.version.outputs.tag }}"
+          gh release upload $tag $env:ZIP_NAME --clobber

--- a/garmin-extract-windows.spec
+++ b/garmin-extract-windows.spec
@@ -1,0 +1,85 @@
+# PyInstaller spec for the Windows build.
+#
+# Produces a `dist/garmin-extract/` onedir bundle containing garmin-extract.exe
+# and all its dependencies. ChromeDriver is NOT bundled — SeleniumBase downloads
+# a matching driver at runtime.
+#
+# Build locally with:
+#   pyinstaller garmin-extract-windows.spec
+#
+# CI builds this on a Windows runner in .github/workflows/build-windows.yml.
+
+# -*- mode: python ; coding: utf-8 -*-
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+block_cipher = None
+
+# ── Hidden imports ───────────────────────────────────────────────────────────
+# PyInstaller's static analysis misses some dynamically-imported modules.
+hiddenimports = []
+hiddenimports += collect_submodules("seleniumbase")
+hiddenimports += collect_submodules("google.auth")
+hiddenimports += collect_submodules("googleapiclient")
+hiddenimports += collect_submodules("google_auth_oauthlib")
+hiddenimports += collect_submodules("keyring.backends")
+
+# ── Data files ───────────────────────────────────────────────────────────────
+datas = []
+datas += collect_data_files("seleniumbase")
+datas += collect_data_files("google_auth_oauthlib")
+
+# Project-local scripts the app invokes via subprocess
+datas += [
+    ("pullers", "pullers"),
+    ("reports", "reports"),
+    ("scripts", "scripts"),
+]
+
+
+a = Analysis(
+    ["garmin_extract/__main__.py"],
+    pathex=[],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="garmin-extract",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,  # windowed app (no console window)
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name="garmin-extract",
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ include = ["garmin_extract*"]
 
 [tool.ruff]
 line-length = 100
+extend-exclude = ["*.spec"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]


### PR DESCRIPTION
## Summary

Closes #32. Adds automated Windows .exe builds via GitHub Actions, attached to GitHub Releases.

## What's in it

- **garmin-extract-windows.spec** — PyInstaller onedir build config
  - Bundles \`pullers/\`, \`reports/\`, \`scripts/\` so subprocess calls work from the exe
  - Collects hidden imports for seleniumbase, google auth, keyring backends
  - Windowed mode (no console window), UPX compressed
- **.github/workflows/build-windows.yml**
  - Triggers on \`v*.*.*\` tag push, plus manual dispatch for retroactive builds
  - Uses \`windows-latest\` runner, Python 3.12
  - Installs \`.[gui]\` + pyinstaller, runs the spec, zips, uploads
  - Attaches \`garmin-extract-windows-vX.Y.Z.zip\` to the matching Release
- **pyproject.toml** — exclude \`*.spec\` from ruff (PyInstaller injects globals)

## Test plan

- [ ] Merge this to main
- [ ] Manually trigger workflow against v1.4.0 tag (retroactive build)
- [ ] Download the zip, extract, run garmin-extract.exe on a clean Windows machine
- [ ] Future: cut v1.4.1 and confirm the exe auto-attaches to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)