### PR TITLE
fix(windows): add missing hidden imports for subprocess scripts

### DIFF
--- a/garmin-extract-windows.spec
+++ b/garmin-extract-windows.spec
@@ -16,10 +16,17 @@ from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 block_cipher = None
 
 # ── Hidden imports ───────────────────────────────────────────────────────────
-# PyInstaller's static analysis misses some dynamically-imported modules.
-hiddenimports = []
+# PyInstaller's static analysis scans the main entry point, but several modules
+# are only imported by subprocess-invoked scripts (pullers/garmin.py,
+# scripts/setup_gmail_auth.py, etc.) — those imports need to be listed here so
+# they get packaged in the bundle.
+hiddenimports = [
+    "dotenv",  # pullers/garmin.py — loads .env credentials
+    "requests_oauthlib",  # scripts/setup_gmail_auth.py — Gmail OAuth flow
+]
 hiddenimports += collect_submodules("seleniumbase")
 hiddenimports += collect_submodules("google.auth")
+hiddenimports += collect_submodules("google.oauth2")  # pullers/_gmail_mfa.py
 hiddenimports += collect_submodules("googleapiclient")
 hiddenimports += collect_submodules("google_auth_oauthlib")
 hiddenimports += collect_submodules("keyring.backends")


### PR DESCRIPTION
## Summary

The PyInstaller spec only listed modules imported by the main GUI entry point. Modules that are only imported by subprocess-invoked scripts (pullers/garmin.py, scripts/setup_gmail_auth.py, pullers/_gmail_mfa.py) would be missing from the bundle, causing the subprocess to crash with \`ImportError\` at runtime.

Without this fix, the v1.4.0 \`.exe\` would bundle fine, launch fine, but any actual pull operation would fail the moment \`pullers/garmin.py\` tries to \`from dotenv import load_dotenv\`.

## Changes
- \`dotenv\` — pullers/garmin.py
- \`requests_oauthlib\` — scripts/setup_gmail_auth.py
- \`google.oauth2\` submodules — pullers/_gmail_mfa.py (google.auth and googleapiclient were already collected)

## Test plan
- [ ] Merge, cut v1.4.1, confirm new exe runs a pull successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)