### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "garmin-extract"
-version = "1.4.0"
+version = "1.4.1"
 description = "Automated Garmin Connect data pipeline using browser automation"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.4.0"
+version = "1.4.1"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary
- Version bump to 1.4.1 for the PyInstaller hidden-imports fix (#38)
- Cutting a new release will trigger the Windows build workflow and produce a fixed .exe

🤖 Generated with [Claude Code](https://claude.com/claude-code)