### PR TITLE
fix(windows): Chrome check, app paths, keyring bundling

### DIFF
--- a/garmin-extract-windows.spec
+++ b/garmin-extract-windows.spec
@@ -23,13 +23,23 @@ block_cipher = None
 hiddenimports = [
     "dotenv",  # pullers/garmin.py — loads .env credentials
     "requests_oauthlib",  # scripts/setup_gmail_auth.py — Gmail OAuth flow
+    # Windows keyring backend dependencies — keyring.backends.Windows uses
+    # pywin32-ctypes to call win32cred (Windows Credential Manager).
+    # PyInstaller's static analysis often misses these since they're imported
+    # dynamically by keyring's backend auto-selection.
+    "win32ctypes",
+    "win32ctypes.pywin32",
+    "win32ctypes.pywin32.win32cred",
+    "win32ctypes.pywin32.pywintypes",
 ]
 hiddenimports += collect_submodules("seleniumbase")
 hiddenimports += collect_submodules("google.auth")
 hiddenimports += collect_submodules("google.oauth2")  # pullers/_gmail_mfa.py
 hiddenimports += collect_submodules("googleapiclient")
 hiddenimports += collect_submodules("google_auth_oauthlib")
+hiddenimports += collect_submodules("keyring")
 hiddenimports += collect_submodules("keyring.backends")
+hiddenimports += collect_submodules("win32ctypes")
 
 # ── Data files ───────────────────────────────────────────────────────────────
 datas = []

--- a/garmin_extract/_credentials.py
+++ b/garmin_extract/_credentials.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from garmin_extract._paths import app_root
 
 _SERVICE = "garmin-extract"
 _EMAIL_KEY = "email"
 _PASSWORD_KEY = "password"
 _PROBE_KEY = "_probe"
-ROOT = Path(__file__).parent.parent
+ROOT = app_root()
 ENV_FILE = ROOT / ".env"
 
 
@@ -88,8 +88,9 @@ def save_to_env(email: str, password: str) -> None:
 def check_credentials() -> tuple[bool, str]:
     """
     Returns (ok, detail) for status display in SetupScreen.
-    Shows where creds came from.
+    Shows where creds came from, or surfaces keyring errors if lookup fails.
     """
+    keyring_error: str | None = None
     try:
         import keyring  # noqa: PLC0415
 
@@ -99,8 +100,8 @@ def check_credentials() -> tuple[bool, str]:
             return True, f"{email}  [dim](keyring)[/]"
         if email:
             return False, f"{email}  [dim](no password in keyring)[/]"
-    except Exception:
-        pass
+    except Exception as exc:
+        keyring_error = str(exc)
 
     email, password = _load_from_env()
     if email and password:
@@ -108,6 +109,8 @@ def check_credentials() -> tuple[bool, str]:
     if email:
         return False, f"{email}  [dim](no password in .env)[/]"
 
+    if keyring_error:
+        return False, f"Keyring error: {keyring_error}"
     return False, "Not configured"
 
 

--- a/garmin_extract/_google_drive.py
+++ b/garmin_extract/_google_drive.py
@@ -17,7 +17,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-ROOT = Path(__file__).parent.parent
+from garmin_extract._paths import app_root
+
+ROOT = app_root()
 TOKEN_FILE = ROOT / ".google_token.json"
 CREDENTIALS_FILE = ROOT / "google_credentials.json"
 CONFIG_FILE = ROOT / ".drive_config.json"

--- a/garmin_extract/_paths.py
+++ b/garmin_extract/_paths.py
@@ -1,0 +1,43 @@
+"""Path helpers — resolve app root correctly for both dev installs and PyInstaller bundles.
+
+In a normal install, files like `.env`, `.mfa_code`, `pullers/`, `reports/` live at
+the project root (the directory containing `pyproject.toml`). Computing that with
+`Path(__file__).parent.parent` works fine.
+
+Inside a PyInstaller onedir bundle, Python modules live in `dist/garmin-extract/_internal/`
+while user-facing files should live alongside `garmin-extract.exe`. `__file__` points
+inside `_internal/`, so the parent-parent trick resolves to the wrong directory.
+
+`app_root()` handles both cases by checking `sys.frozen`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def app_root() -> Path:
+    """Return the directory where user-facing files (config, data, scripts) live.
+
+    - Dev install: project root (containing pyproject.toml)
+    - Frozen (PyInstaller onedir): the directory containing the .exe
+    """
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).parent
+    # Dev install: this file is at <root>/garmin_extract/_paths.py
+    return Path(__file__).resolve().parent.parent
+
+
+def bundle_root() -> Path:
+    """Return the directory containing bundled data files (pullers/, reports/, scripts/).
+
+    - Dev install: same as app_root() — the project root
+    - Frozen: `sys._MEIPASS` (PyInstaller's _internal directory) where data files land
+    """
+    if getattr(sys, "frozen", False):
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            return Path(meipass)
+        return Path(sys.executable).parent / "_internal"
+    return Path(__file__).resolve().parent.parent

--- a/garmin_extract/gui/screens/pull_progress.py
+++ b/garmin_extract/gui/screens/pull_progress.py
@@ -7,7 +7,6 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import date, timedelta
-from pathlib import Path
 from threading import Thread
 
 from PySide6.QtCore import QObject, Qt, Signal
@@ -24,7 +23,10 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-ROOT = Path(__file__).parent.parent.parent.parent
+from garmin_extract._paths import app_root, bundle_root
+
+ROOT = app_root()  # user-facing files (.mfa_code, .env, data/)
+SCRIPTS_ROOT = bundle_root()  # subprocess script files (pullers/, reports/)
 MFA_FILE = ROOT / ".mfa_code"
 
 
@@ -365,19 +367,19 @@ class PullProgressDialog(QDialog):
 
     def _build_cmd(self) -> list[str]:
         if self._rebuild_only:
-            return [sys.executable, "-u", str(ROOT / "reports" / "build_garmin_csvs.py")]
+            return [sys.executable, "-u", str(SCRIPTS_ROOT / "reports" / "build_garmin_csvs.py")]
         if self._zip_path:
             return [
                 sys.executable,
                 "-u",
-                str(ROOT / "pullers" / "garmin_import_export.py"),
+                str(SCRIPTS_ROOT / "pullers" / "garmin_import_export.py"),
                 "--zip",
                 self._zip_path,
             ]
         cmd = [
             sys.executable,
             "-u",
-            str(ROOT / "pullers" / "garmin.py"),
+            str(SCRIPTS_ROOT / "pullers" / "garmin.py"),
             "--date",
             self._start_date,
             "--days",

--- a/garmin_extract/menu.py
+++ b/garmin_extract/menu.py
@@ -117,13 +117,35 @@ def save_env(vals: dict[str, str]) -> None:
 
 def _find_chrome() -> tuple[bool, str | None]:
     system = platform.system()
+
+    # Windows: chrome.exe --version launches Chrome instead of printing version.
+    # Check standard install paths and read VersionInfo via PowerShell.
     if system == "Windows":
-        candidates: list[str] = [
-            "chrome",
+        paths = [
             r"C:\Program Files\Google\Chrome\Application\chrome.exe",
             r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+            os.path.expandvars(r"%LOCALAPPDATA%\Google\Chrome\Application\chrome.exe"),
         ]
-    elif system == "Darwin":
+        for path in paths:
+            if not Path(path).is_file():
+                continue
+            try:
+                ps = f"(Get-Item '{path}').VersionInfo.ProductVersion"
+                r = subprocess.run(
+                    ["powershell", "-NoProfile", "-Command", ps],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                version = r.stdout.strip() if r.returncode == 0 else ""
+                label = f"Google Chrome {version}" if version else "Google Chrome"
+                return True, label
+            except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+                return True, "Google Chrome (version unknown)"
+        return False, None
+
+    # macOS / Linux: chrome --version prints version and exits
+    if system == "Darwin":
         candidates = [
             "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
             "google-chrome",


### PR DESCRIPTION
## Summary

Three Windows fixes bundled together — all reported by real-world testing on v1.4.1.

### 1. Chrome prereq check launches Chrome instead of checking version
\`chrome.exe --version\` on Windows opens Chrome normally instead of printing the version string. Check standard install paths and read ProductVersion via PowerShell's \`Get-Item\` (doesn't execute the binary). Linux/macOS unchanged.

### 2. Path resolution broken in PyInstaller bundle
\`Path(__file__).parent.parent\` resolves to \`_internal/\` inside the bundle instead of the directory containing the .exe. Added \`garmin_extract/_paths.py\` with frozen-aware \`app_root()\` and \`bundle_root()\` helpers. Updated \`_credentials.py\`, \`_google_drive.py\`, and \`gui/screens/pull_progress.py\`.

### 3. Windows keyring backend not in bundle
\`keyring.backends.Windows\` uses \`pywin32-ctypes\` for Credential Manager access, but PyInstaller's static analysis misses the dynamic imports. Added \`win32ctypes\` submodules to the spec's hiddenimports.

### 4. Surface keyring errors
\`check_credentials()\` was silently swallowing all keyring exceptions and returning "Not configured" — indistinguishable from "never saved". Now returns \`"Keyring error: <message>"\` so real failures are visible.

## Test plan
- [ ] Merge, cut v1.4.2, download new exe
- [ ] Prereq check should pass without opening Chrome
- [ ] Credentials save → status shows "Configured" (not "Not Configured")
- [ ] If keyring is still broken, error message appears in the status line

🤖 Generated with [Claude Code](https://claude.com/claude-code)