### PR TITLE
fix(windows): subprocess scripts couldn't run from frozen exe

### DIFF
--- a/garmin_extract/__main__.py
+++ b/garmin_extract/__main__.py
@@ -1,4 +1,64 @@
-from garmin_extract.cli import main
+"""Package entry point — routes to the CLI, or executes a script if frozen.
+
+The frozen Windows exe bundles the app itself, but subprocess-invoked scripts
+(pullers/garmin.py, reports/build_garmin_csvs.py, etc.) still need to run.
+In a PyInstaller bundle `sys.executable` is garmin-extract.exe (not python.exe),
+so a plain `subprocess.Popen([sys.executable, "-u", script, ...])` would just
+re-launch the CLI with the wrong args.
+
+To keep the subprocess pattern working, we intercept `-u <script>` here and
+execute that script via `runpy` — mimicking what `python -u script` does.
+This path only fires when `sys.frozen` is True, so regular installs are
+unaffected.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def _run_script_if_frozen() -> None:
+    """If invoked as `garmin-extract.exe -u <script> [args...]`, run the script."""
+    if not getattr(sys, "frozen", False):
+        return
+    if len(sys.argv) < 3 or sys.argv[1] != "-u":
+        return
+
+    script = sys.argv[2]
+    sys.argv = [script] + sys.argv[3:]
+
+    # Add the script's directory to sys.path so sibling imports work
+    # (e.g. pullers/garmin.py does `from _gmail_mfa import ...`)
+    from pathlib import Path
+
+    script_dir = str(Path(script).resolve().parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+
+    # Unbuffered line output so the GUI sees progress in real time
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(line_buffering=True, write_through=True)
+        except Exception:
+            pass
+
+    import runpy
+
+    try:
+        runpy.run_path(script, run_name="__main__")
+    except SystemExit as e:
+        sys.exit(e.code if e.code is not None else 0)
+    except Exception:
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+    sys.exit(0)
+
+
+_run_script_if_frozen()
+
+from garmin_extract.cli import main  # noqa: E402
 
 if __name__ == "__main__":
     main()

--- a/pullers/_gmail_mfa.py
+++ b/pullers/_gmail_mfa.py
@@ -8,10 +8,14 @@ Falls back gracefully if credentials are missing or the API call fails.
 
 import base64
 import re
+import sys
 import time
 from pathlib import Path
 
-ROOT = Path(__file__).parent.parent
+if getattr(sys, "frozen", False):
+    ROOT = Path(sys.executable).parent
+else:
+    ROOT = Path(__file__).parent.parent
 CREDENTIALS_FILE = ROOT / "google_credentials.json"
 TOKEN_FILE = ROOT / ".google_token.json"
 

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -31,7 +31,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-ROOT = Path(__file__).parent.parent
+# ROOT points to the app directory — containing data/, .env, .garmin_browser_profile/.
+# In a PyInstaller bundle, __file__ is inside _internal/ so we use sys.executable's
+# parent (the directory containing garmin-extract.exe) instead.
+if getattr(sys, "frozen", False):
+    ROOT = Path(sys.executable).parent
+else:
+    ROOT = Path(__file__).parent.parent
+
 DATA_DIR = ROOT / "data" / "garmin"
 PROFILE_DIR = ROOT / ".garmin_browser_profile"
 MFA_FILE = ROOT / ".mfa_code"

--- a/pullers/garmin_import_export.py
+++ b/pullers/garmin_import_export.py
@@ -19,7 +19,11 @@ from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 
-ROOT = Path(__file__).parent.parent
+if getattr(sys, "frozen", False):
+    ROOT = Path(sys.executable).parent
+else:
+    ROOT = Path(__file__).parent.parent
+
 DATA_DIR = ROOT / "data" / "garmin"
 
 

--- a/reports/build_garmin_csvs.py
+++ b/reports/build_garmin_csvs.py
@@ -17,12 +17,17 @@ Usage:
 import argparse
 import csv
 import json
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-ROOT = Path(__file__).parent.parent
+if getattr(sys, "frozen", False):
+    ROOT = Path(sys.executable).parent
+else:
+    ROOT = Path(__file__).parent.parent
+
 DATA_DIR = ROOT / "data" / "garmin"
-OUT_DIR = Path(__file__).parent
+OUT_DIR = ROOT / "reports"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/setup_gmail_auth.py
+++ b/scripts/setup_gmail_auth.py
@@ -14,7 +14,11 @@ import sys
 import time
 from pathlib import Path
 
-ROOT = Path(__file__).parent.parent
+if getattr(sys, "frozen", False):
+    ROOT = Path(sys.executable).parent
+else:
+    ROOT = Path(__file__).parent.parent
+
 CREDENTIALS_FILE = ROOT / "google_credentials.json"
 TOKEN_FILE = ROOT / ".google_token.json"
 CODE_FILE = ROOT / ".gmail_auth_code"


### PR DESCRIPTION
## Summary

Fixes a critical bug where any pull action from the Windows GUI would fail instantly with \`error: unrecognized arguments: -u C:\\...\\_internal\\pullers\\garmin.py\`.

## Root cause

In a PyInstaller frozen bundle, \`sys.executable\` is \`garmin-extract.exe\` — not \`python.exe\`. When the GUI does \`subprocess.Popen([sys.executable, "-u", script, ...])\`, it re-launches the CLI with Python-flavored args that argparse correctly rejects.

## Fix

1. **Script-runner shim in \`__main__.py\`** — when \`sys.frozen\` is True and \`sys.argv[1] == "-u"\`, execute the target script via \`runpy\` and exit. Mimics what \`python -u script\` does natively. Dev installs (where \`sys.executable\` is Python) are unaffected.

2. **ROOT path fix in subprocess scripts** — \`pullers/garmin.py\`, \`pullers/_gmail_mfa.py\`, \`pullers/garmin_import_export.py\`, \`reports/build_garmin_csvs.py\`, \`scripts/setup_gmail_auth.py\` all used \`Path(__file__).parent.parent\` which resolves to \`_internal/\` inside the bundle. Fixed to use \`Path(sys.executable).parent\` when frozen.

3. **sys.path injection** — the runpy shim adds the script's directory to sys.path so sibling imports (e.g. \`from _gmail_mfa import ...\` in pullers/garmin.py) work.

## Test plan
- [ ] Merge, cut v1.4.3, test "Yesterday" pull on Windows — should actually reach Garmin now

🤖 Generated with [Claude Code](https://claude.com/claude-code)