### PR TITLE
fix: force UTF-8 encoding in Windows subprocess pipeline (#44)

### DIFF
--- a/garmin_extract/__main__.py
+++ b/garmin_extract/__main__.py
@@ -35,10 +35,11 @@ def _run_script_if_frozen() -> None:
     if script_dir not in sys.path:
         sys.path.insert(0, script_dir)
 
-    # Unbuffered line output so the GUI sees progress in real time
+    # Unbuffered UTF-8 output so the GUI sees progress in real time
+    # (Windows default pipe encoding is cp1252 which can't encode ✓/✗ etc.)
     for stream in (sys.stdout, sys.stderr):
         try:
-            stream.reconfigure(line_buffering=True, write_through=True)
+            stream.reconfigure(encoding="utf-8", line_buffering=True, write_through=True)
         except Exception:
             pass
 

--- a/garmin_extract/gui/screens/pull_progress.py
+++ b/garmin_extract/gui/screens/pull_progress.py
@@ -391,6 +391,7 @@ class PullProgressDialog(QDialog):
 
     def _run_pull(self, cmd: list[str]) -> None:
         env = os.environ.copy()
+        env["PYTHONUTF8"] = "1"  # force UTF-8 I/O in subprocess (Windows cp1252 can't encode ✓)
         if self._email:
             env["GARMIN_EMAIL"] = self._email
         if self._password:
@@ -402,7 +403,7 @@ class PullProgressDialog(QDialog):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 stdin=subprocess.DEVNULL,
-                text=True,
+                encoding="utf-8",
                 cwd=str(ROOT),
                 env=env,
             )


### PR DESCRIPTION
## Summary

- Set `PYTHONUTF8=1` in subprocess env so the child process uses UTF-8 for all I/O — fixes `UnicodeEncodeError` on cp1252 Windows pipes when printing `✓`/`✗` characters
- Replace `text=True` with `encoding="utf-8"` on `Popen` so the parent side also reads stdout as UTF-8
- Add `encoding="utf-8"` to `stream.reconfigure()` in the `__main__` script-runner shim (covers the frozen `.exe` code path)

Closes #44

## Test plan

- [ ] Run a data pull on Windows via the `.exe` — should complete `pull_profile_data()` without crashing
- [ ] Verify `✓` and `✗` characters appear correctly in the pull progress log panel
- [ ] Verify multi-day pull metrics panel still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)