### PR TITLE
fix: extend MFA timeout to 30 min, use headless Chrome on Windows (#46)

### DIFF
--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -7,7 +7,8 @@ Cloudflare never blocks us. The browser logs in once via SSO and keeps a
 persistent session; subsequent runs load the saved profile and skip login.
 
 On headless Linux (no $DISPLAY), Chrome runs inside a virtual framebuffer
-(Xvfb). On desktop Linux, Windows, and macOS it runs directly.
+(Xvfb). On Windows, Chrome runs in headless=new mode so no browser window
+appears. On desktop Linux and macOS it runs directly.
 
 Usage:
     python pullers/garmin.py                         # yesterday
@@ -100,9 +101,9 @@ def wait_for_mfa() -> str:
     MFA_FILE.unlink(missing_ok=True)
     print("=" * 50)
     print(f"Run: echo YOUR_CODE > {MFA_FILE}")
-    print("Waiting up to 5 minutes...")
+    print("Waiting up to 30 minutes...")
     print("=" * 50)
-    for _ in range(300):
+    for _ in range(1800):
         if MFA_FILE.exists():
             code = MFA_FILE.read_text().strip()
             MFA_FILE.unlink(missing_ok=True)
@@ -637,7 +638,10 @@ def main():
     try:
         print("Launching browser...")
         PROFILE_DIR.mkdir(exist_ok=True)
-        with SB(uc=True, headless=False, xvfb=False, user_data_dir=str(PROFILE_DIR)) as sb:
+        # On Windows, use Chrome's newer headless mode so the browser window stays hidden.
+        # On Linux+Xvfb the virtual framebuffer already hides it, so headless=False is correct.
+        use_headless = platform.system() == "Windows"
+        with SB(uc=True, headless=use_headless, xvfb=False, user_data_dir=str(PROFILE_DIR)) as sb:
             ensure_logged_in(sb)
 
             print("Getting display name...")


### PR DESCRIPTION
## Summary

- **MFA timeout:** `range(300)` → `range(1800)` — gives the user the full 30-minute Garmin code validity window instead of aborting after 5 minutes
- **Windows headless:** `headless=False` → `platform.system() == "Windows"` — on Windows, Chrome now runs in `--headless=new` mode so no browser window pops up; on Linux+Xvfb the behaviour is unchanged

Closes #46

## Risk note

Chrome headless is detectable in principle. If Garmin/Cloudflare blocks the headless session, login will fail silently. **Needs real Windows validation.** If the buddy's test shows a login failure or the app hangs on the login page, we revert `use_headless` to `False`.

## Test plan

- [ ] Run a data pull on Windows — browser should not appear, pull should complete normally
- [ ] Enter MFA slowly (wait >5 min if possible) — should still succeed up to 30 min
- [ ] Confirm Linux behaviour unchanged (Xvfb path still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)