### PR TITLE
revert: headless Chrome on Windows — incompatible with UC reconnect (#46)

### DIFF
--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -7,8 +7,7 @@ Cloudflare never blocks us. The browser logs in once via SSO and keeps a
 persistent session; subsequent runs load the saved profile and skip login.
 
 On headless Linux (no $DISPLAY), Chrome runs inside a virtual framebuffer
-(Xvfb). On Windows, Chrome runs in headless=new mode so no browser window
-appears. On desktop Linux and macOS it runs directly.
+(Xvfb). On desktop Linux, Windows, and macOS it runs directly.
 
 Usage:
     python pullers/garmin.py                         # yesterday
@@ -638,10 +637,9 @@ def main():
     try:
         print("Launching browser...")
         PROFILE_DIR.mkdir(exist_ok=True)
-        # On Windows, use Chrome's newer headless mode so the browser window stays hidden.
-        # On Linux+Xvfb the virtual framebuffer already hides it, so headless=False is correct.
-        use_headless = platform.system() == "Windows"
-        with SB(uc=True, headless=use_headless, xvfb=False, user_data_dir=str(PROFILE_DIR)) as sb:
+        # headless=False required — UC mode's uc_open_with_reconnect closes and reopens the
+        # Chrome window as part of its Cloudflare bypass; headless mode breaks that mechanism.
+        with SB(uc=True, headless=False, xvfb=False, user_data_dir=str(PROFILE_DIR)) as sb:
             ensure_logged_in(sb)
 
             print("Getting display name...")


### PR DESCRIPTION
## Summary

Reverts the `headless=True` on Windows change from #47.

`uc_open_with_reconnect()` closes and reopens the Chrome window as part of its Cloudflare bypass mechanism. In headless mode there's no window to close, so the call blocks for 20 seconds then throws:

```
selenium.common.exceptions.WebDriverException: Message: unknown error: failed to close window in 20 seconds
```

Headless mode is a dead end for UC mode. The Chrome window will remain visible on Windows — this is a known limitation of the Cloudflare bypass approach.

The MFA timeout fix (5 min → 30 min) from the same PR is unaffected.

Closes #46 (headless portion — won't fix)

## Test plan

- [ ] Run a data pull on Windows — browser appears briefly, pull completes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)