### PR TITLE
fix: handle EOFError in MFA stdin check on Windows (#50)

### DIFF
--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -87,15 +87,20 @@ def wait_for_mfa() -> str:
     except ImportError:
         pass
 
-    # Interactive fallback — prompt inline when stdin is a terminal
+    # Interactive fallback — prompt inline when stdin is a real terminal.
+    # Guard with EOFError: on Windows the NUL device can report isatty()=True
+    # even when stdin is not interactive (e.g. subprocess with DEVNULL).
     print()
     print("MFA REQUIRED — check your email for the 6-digit code.")
     if sys.stdin.isatty():
-        while True:
-            code = input("  Enter code: ").strip()
-            if code:
-                return code
-            print("  No code entered — please try again.")
+        try:
+            while True:
+                code = input("  Enter code: ").strip()
+                if code:
+                    return code
+                print("  No code entered — please try again.")
+        except EOFError:
+            pass  # stdin not truly interactive — fall through to file poll
 
     # Non-interactive fallback (cron / piped stdin) — poll a file
     MFA_FILE.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

On Windows, `NUL` (the null device used for `stdin=DEVNULL`) reports `isatty()=True`. This caused `wait_for_mfa()` to call `input()`, get `EOFError`, which was caught and swallowed by the outer `_do_login` loop — so the function looped endlessly and the file-poll path (which the GUI MFA dialog depends on) was never reached.

Fix: wrap the `isatty()`/`input()` block with `try/except EOFError` and fall through to the file-poll path.

Closes #50

## Test plan

- [ ] GUI pull on Windows triggers MFA → MFA dialog appears, user enters code, pull continues
- [ ] CLI pull in a real terminal on Windows still prompts inline as before
- [ ] Linux behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)