### PR TITLE
feat: make credentials optional when a display is available (#52)

### DIFF
--- a/garmin_extract/gui/screens/pull_progress.py
+++ b/garmin_extract/gui/screens/pull_progress.py
@@ -105,17 +105,21 @@ class _RuntimeCredsDialog(QDialog):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        self.setWindowTitle("Enter Garmin Connect Credentials")
+        self.setWindowTitle("Garmin Connect Login")
         self.setMinimumWidth(450)
         self.setModal(True)
 
         self.result_email = ""
         self.result_password = ""
+        self.result_manual = False
 
         layout = QVBoxLayout(self)
         layout.setSpacing(10)
 
-        hint = QLabel("No saved credentials found. These will not be stored.")
+        hint = QLabel(
+            "No saved credentials found. Enter them below, or log in manually in the browser."
+        )
+        hint.setWordWrap(True)
         hint.setStyleSheet("color: #6c7086;")
         layout.addWidget(hint)
 
@@ -137,6 +141,10 @@ class _RuntimeCredsDialog(QDialog):
         layout.addWidget(self._error)
 
         btn_layout = QHBoxLayout()
+        manual = QPushButton("Log in manually")
+        manual.setStyleSheet("color: #89b4fa;")
+        manual.clicked.connect(self._use_manual)
+        btn_layout.addWidget(manual)
         btn_layout.addStretch()
         cancel = QPushButton("Cancel")
         cancel.clicked.connect(self.reject)
@@ -161,6 +169,10 @@ class _RuntimeCredsDialog(QDialog):
             return
         self.result_email = email
         self.result_password = password
+        self.accept()
+
+    def _use_manual(self) -> None:
+        self.result_manual = True
         self.accept()
 
 
@@ -353,8 +365,10 @@ class PullProgressDialog(QDialog):
         else:
             dlg = _RuntimeCredsDialog(self)
             if dlg.exec() == QDialog.DialogCode.Accepted:
-                self._email = dlg.result_email
-                self._password = dlg.result_password
+                if not dlg.result_manual:
+                    self._email = dlg.result_email
+                    self._password = dlg.result_password
+                # result_manual=True: leave _email/_password empty — subprocess uses manual login
                 self._start_pull()
             else:
                 self.reject()

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -56,6 +56,13 @@ def needs_virtual_display() -> bool:
     return platform.system() == "Linux" and not os.environ.get("DISPLAY")
 
 
+def has_display() -> bool:
+    """Return True when a real/virtual display is available for manual interaction."""
+    if platform.system() == "Windows":
+        return True
+    return bool(os.environ.get("DISPLAY"))
+
+
 def start_xvfb(display=":99"):
     proc = subprocess.Popen(
         ["Xvfb", display, "-screen", "0", "1280x720x24"],
@@ -124,8 +131,12 @@ def wait_for_mfa() -> str:
 # ---------------------------------------------------------------------------
 
 
-def ensure_logged_in(sb):
-    """Check session and log in if needed."""
+def ensure_logged_in(sb, email: str = "", password: str = "") -> None:
+    """Check session and log in if needed.
+
+    If email/password are provided, login is automated. Otherwise the browser
+    opens to the login page and waits for the user to log in manually.
+    """
     # Remove stale Chrome lock files that prevent profile reuse
     lock = PROFILE_DIR / "SingletonLock"
     if lock.exists():
@@ -135,22 +146,36 @@ def ensure_logged_in(sb):
     sb.sleep(3)
 
     if "sign-in" in sb.get_current_url() or "sso.garmin.com" in sb.get_current_url():
-        print("Session expired or new — logging in...")
-        _do_login(sb)
+        if email and password:
+            print("Session expired or new — logging in...")
+            _do_login(sb, email, password)
+        else:
+            _wait_for_manual_login(sb)
     else:
         print("Existing session active.")
 
 
-def _do_login(sb):
+def _wait_for_manual_login(sb) -> None:
+    """Wait up to 5 minutes for the user to log in manually via the browser."""
+    print("No credentials configured — please log in to Garmin Connect in the browser.")
+    print("Waiting up to 5 minutes for login to complete...")
+    for _ in range(300):
+        url = sb.get_current_url()
+        if "connect.garmin.com" in url and "sso.garmin.com" not in url and "sign-in" not in url:
+            print("Login detected.")
+            return
+        time.sleep(1)
+    print("ERROR: Timed out waiting for manual login.")
+    sys.exit(1)
+
+
+def _do_login(sb, email: str, password: str) -> None:
     sb.uc_open_with_reconnect(
         "https://sso.garmin.com/portal/sso/en-US/sign-in"
         "?clientId=GarminConnect&consumeServiceTicket=false",
         reconnect_time=6,
     )
     sb.sleep(5)
-
-    email = os.environ["GARMIN_EMAIL"]
-    password = os.environ["GARMIN_PASSWORD"]
 
     sb.type("#email", email)
     sb.type("#password", password)
@@ -626,11 +651,14 @@ def main():
         print("ERROR: seleniumbase not installed. Run: pip install -r requirements.txt")
         sys.exit(1)
 
-    email = os.environ.get("GARMIN_EMAIL")
-    password = os.environ.get("GARMIN_PASSWORD")
+    email = os.environ.get("GARMIN_EMAIL", "")
+    password = os.environ.get("GARMIN_PASSWORD", "")
     if not email or not password:
-        print("ERROR: GARMIN_EMAIL and GARMIN_PASSWORD must be set in .env")
-        sys.exit(1)
+        if not has_display():
+            print("ERROR: No credentials set and no display available for manual login.")
+            print("Set GARMIN_EMAIL and GARMIN_PASSWORD in .env or via keyring.")
+            sys.exit(1)
+        print("No credentials configured — manual browser login will be required.")
 
     args = parse_args()
     dates = [args.date + timedelta(days=i) for i in range(args.days)]
@@ -646,7 +674,7 @@ def main():
         # headless=False required — UC mode's uc_open_with_reconnect closes and reopens the
         # Chrome window as part of its Cloudflare bypass; headless mode breaks that mechanism.
         with SB(uc=True, headless=False, xvfb=False, user_data_dir=str(PROFILE_DIR)) as sb:
-            ensure_logged_in(sb)
+            ensure_logged_in(sb, email, password)
 
             print("Getting display name...")
             display_name, uuid = get_display_name(sb)


### PR DESCRIPTION
## Summary

Credentials are now optional when a display is available. If none are configured, the browser opens to Garmin Connect and the tool waits up to 5 minutes for the user to log in manually. Session persistence means subsequent pulls skip login entirely.

**Behaviour matrix:**

| Credentials | Display available | Result |
|---|---|---|
| Yes | Any | Automated login (unchanged) |
| No | Yes (Windows / Linux `$DISPLAY`) | Manual browser login |
| No | No (headless Linux) | Error — can't log in without a screen |

### Changes

**`pullers/garmin.py`**
- `has_display()` — True on Windows, True on Linux if `$DISPLAY` set
- `_wait_for_manual_login(sb)` — polls URL until off `sso.garmin.com`, 5 min timeout
- `ensure_logged_in(sb, email, password)` — branches on creds vs manual
- `_do_login(sb, email, password)` — email/password passed in, not read from env
- `main()` — skips hard-exit when display available, prints friendly message

**`garmin_extract/gui/screens/pull_progress.py`**
- `_RuntimeCredsDialog` — "Log in manually" button (blue, left-aligned); sets `result_manual=True`
- `_check_creds_and_start()` — if `result_manual`, starts pull without setting `_email`/`_password`

Closes #52

## Test plan

- [ ] Windows, no credentials saved: credentials dialog shows "Log in manually" button; clicking it opens browser, user logs in, pull completes
- [ ] Windows, credentials saved: automated login as before (dialog doesn't appear)
- [ ] Linux with `$DISPLAY`, no credentials: manual login path works
- [ ] Linux headless, no credentials: exits with clear error message
- [ ] Existing session on any platform: "Existing session active" — no login needed regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)