### PR TITLE
feat: add Clear Credentials button to Setup screen

### DIFF
--- a/garmin_extract/_credentials.py
+++ b/garmin_extract/_credentials.py
@@ -114,6 +114,30 @@ def check_credentials() -> tuple[bool, str]:
     return False, "Not configured"
 
 
+def clear_credentials() -> tuple[bool, str]:
+    """Remove credentials from keyring and .env. Returns (ok, detail)."""
+    errors: list[str] = []
+
+    try:
+        import keyring  # noqa: PLC0415
+
+        for key in (_EMAIL_KEY, _PASSWORD_KEY):
+            try:
+                keyring.delete_password(_SERVICE, key)
+            except Exception:
+                pass  # not stored there — fine
+    except ImportError:
+        pass
+    except Exception as exc:
+        errors.append(str(exc))
+
+    _scrub_env()
+
+    if errors:
+        return False, f"Errors: {', '.join(errors)}"
+    return True, "Credentials cleared"
+
+
 def _scrub_env() -> None:
     """Remove Garmin credentials from .env after a successful keyring save."""
     if not ENV_FILE.exists():

--- a/garmin_extract/gui/screens/setup.py
+++ b/garmin_extract/gui/screens/setup.py
@@ -287,6 +287,11 @@ class CredentialsDialog(QDialog):
 
         # Buttons
         btn_layout = QHBoxLayout()
+        self._clear_btn = QPushButton("Clear Credentials")
+        self._clear_btn.setStyleSheet("color: #f38ba8;")
+        self._clear_btn.setEnabled(False)
+        self._clear_btn.clicked.connect(self._clear)
+        btn_layout.addWidget(self._clear_btn)
         btn_layout.addStretch()
         cancel_btn = QPushButton("Cancel")
         cancel_btn.clicked.connect(self.reject)
@@ -304,12 +309,13 @@ class CredentialsDialog(QDialog):
         try:
             from garmin_extract._credentials import load_credentials
 
-            email, _ = load_credentials()
+            email, password = load_credentials()
             if email:
                 self._email.setText(email)
                 self._password.setFocus()
             else:
                 self._email.setFocus()
+            self._clear_btn.setEnabled(bool(email or password))
         except Exception:
             self._email.setFocus()
 
@@ -347,6 +353,22 @@ class CredentialsDialog(QDialog):
                 self._warning.show()
 
         QTimer.singleShot(50, _apply)
+
+    def _clear(self) -> None:
+        from garmin_extract._credentials import clear_credentials
+
+        self._error.hide()
+        self._success.hide()
+        ok, detail = clear_credentials()
+        if ok:
+            self._email.clear()
+            self._password.clear()
+            self._clear_btn.setEnabled(False)
+            self._success.setText("Credentials cleared.")
+            self._success.show()
+        else:
+            self._error.setText(f"Clear failed: {detail}")
+            self._error.show()
 
     def _save(self) -> None:
         from garmin_extract._credentials import save_to_env, save_to_keyring


### PR DESCRIPTION
## Summary

- `clear_credentials()` in `_credentials.py` — removes from keyring (both email + password keys) and scrubs `.env`
- `CredentialsDialog` in `setup.py` — red "Clear Credentials" button on the left side of the button row; only enabled when credentials are loaded; clears fields and disables itself on success

## Test plan

- [ ] Open Setup → Garmin Credentials with creds saved — "Clear Credentials" button is enabled
- [ ] Click Clear — fields empty, button greys out, success message shows, status card updates to "Not configured"
- [ ] Open Setup → Garmin Credentials with no creds — "Clear Credentials" button is disabled
- [ ] Verify cleared from keyring (Windows Credential Manager) and/or .env

🤖 Generated with [Claude Code](https://claude.com/claude-code)