### PR TITLE
fix: scope _SectionCard stylesheet to stop label bleed on Automation page

### DIFF
--- a/garmin_extract/gui/screens/automation.py
+++ b/garmin_extract/gui/screens/automation.py
@@ -91,12 +91,12 @@ class _SectionCard(QFrame):
 
     def __init__(self, title: str, subtitle: str, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self.setObjectName("section-card")
         self.setStyleSheet("""
-            QFrame {
+            QFrame#section-card {
                 background-color: #313244;
                 border: 1px solid #45475a;
                 border-radius: 8px;
-                padding: 16px;
             }
             """)
 


### PR DESCRIPTION
## Bug

Automation page cards rendered blank — section titles, subtitles, and status text were invisible.

## Root cause

In Qt, `QLabel` inherits from `QFrame`. The `_SectionCard` stylesheet used `QFrame { border: 1px solid; border-radius: 8px; padding: 16px; }` — a type selector that cascades to every `QFrame` descendant, including child `QLabel`s. Each label got a border, 8px corner radius, and 16px padding, pushing their text content outside the visible area.

`_StatusCard` in `setup.py` was unaffected because it correctly scopes its selector to `QFrame#status-card`.

## Fix

Add `setObjectName("section-card")` and scope the selector to `QFrame#section-card`. Also removed the `padding: 16px` from the stylesheet — the layout already sets `setContentsMargins(16, 12, 16, 12)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)