### PR TITLE
[windows] Windows-aware browser detection and platform-conditional UI

### DIFF
--- a/garmin_extract/_browser.py
+++ b/garmin_extract/_browser.py
@@ -1,0 +1,33 @@
+"""Browser detection — finds the best available Chromium browser on Windows."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def detect_windows_browser() -> str | None:
+    """Return the path to the first available Chromium browser on Windows.
+
+    Priority: Chrome → Brave → Edge. Returns None if none are found.
+    Only meaningful on Windows; always returns None on other platforms.
+    """
+    prog = os.environ.get("PROGRAMFILES", r"C:\Program Files")
+    prog_x86 = os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)")
+    local = os.environ.get("LOCALAPPDATA", "")
+    candidates = [
+        # Chrome
+        Path(prog) / "Google/Chrome/Application/chrome.exe",
+        Path(prog_x86) / "Google/Chrome/Application/chrome.exe",
+        Path(local) / "Google/Chrome/Application/chrome.exe",
+        # Brave
+        Path(prog) / "BraveSoftware/Brave-Browser/Application/brave.exe",
+        Path(local) / "BraveSoftware/Brave-Browser/Application/brave.exe",
+        # Edge — guaranteed fallback on any Windows 10/11 machine
+        Path(prog_x86) / "Microsoft/Edge/Application/msedge.exe",
+        Path(prog) / "Microsoft/Edge/Application/msedge.exe",
+    ]
+    for path in candidates:
+        if path.exists():
+            return str(path)
+    return None

--- a/garmin_extract/cli.py
+++ b/garmin_extract/cli.py
@@ -32,10 +32,11 @@ def _is_tui_capable() -> bool:
     # Explicit opt-outs
     if os.environ.get("CI") or os.environ.get("GARMIN_NO_TUI"):
         return False
-    # Dumb / missing terminal
-    term = os.environ.get("TERM", "")
-    if term in ("dumb", ""):
-        return False
+    # TERM is a Unix concept — Windows PowerShell/cmd don't set it, but Textual works fine there
+    if sys.platform != "win32":
+        term = os.environ.get("TERM", "")
+        if term in ("dumb", ""):
+            return False
     # No TTY (e.g. piped output, cron)
     if not sys.stdout.isatty():
         return False

--- a/garmin_extract/gui/app.py
+++ b/garmin_extract/gui/app.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import platform
 import sys
 
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QMessageBox
 
 from garmin_extract import __version__
 from garmin_extract.gui.main_window import MainWindow
@@ -17,6 +18,21 @@ def run(dry_run: bool = False, verbose: int = 0) -> None:
     app.setApplicationName("garmin-extract")
     app.setApplicationVersion(__version__)
     app.setStyleSheet(DARK_STYLESHEET)
+
+    if platform.system() == "Windows":
+        from garmin_extract._browser import detect_windows_browser
+
+        if detect_windows_browser() is None:
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Icon.Critical)
+            msg.setWindowTitle("No browser found")
+            msg.setText("No supported browser found.")
+            msg.setInformativeText(
+                "garmin-extract requires Chrome, Brave, or Edge.\n"
+                "Install Chrome from google.com/chrome and restart."
+            )
+            msg.exec()
+            sys.exit(1)
 
     window = MainWindow()
     window.show()

--- a/garmin_extract/gui/main_window.py
+++ b/garmin_extract/gui/main_window.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import platform
+
 from PySide6.QtWidgets import (
     QHBoxLayout,
     QListWidget,
@@ -14,6 +16,8 @@ from garmin_extract import __version__
 from garmin_extract.gui.screens.automation import AutomationPage
 from garmin_extract.gui.screens.pull_data import PullDataPage
 from garmin_extract.gui.screens.setup import SetupPage
+
+_WINDOWS = platform.system() == "Windows"
 
 
 class MainWindow(QMainWindow):
@@ -35,14 +39,20 @@ class MainWindow(QMainWindow):
         self.sidebar = QListWidget()
         self.sidebar.setObjectName("sidebar")
         self.sidebar.setFixedWidth(200)
-        for label in ("Initial Setup", "Pull Data", "Automation"):
+        nav_items = (
+            ("Pull Data", "Automation")
+            if _WINDOWS
+            else ("Initial Setup", "Pull Data", "Automation")
+        )
+        for label in nav_items:
             self.sidebar.addItem(label)
         self.sidebar.setCurrentRow(0)
         layout.addWidget(self.sidebar)
 
         # ── Content area ──────────────────────────────
         self.stack = QStackedWidget()
-        self.stack.addWidget(SetupPage())
+        if not _WINDOWS:
+            self.stack.addWidget(SetupPage())
         self.stack.addWidget(PullDataPage())
         self.stack.addWidget(AutomationPage())
         layout.addWidget(self.stack)

--- a/garmin_extract/gui/screens/automation.py
+++ b/garmin_extract/gui/screens/automation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import platform
 from pathlib import Path
 from threading import Thread
 
@@ -15,6 +16,8 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+
+_WINDOWS = platform.system() == "Windows"
 
 ROOT = Path(__file__).parent.parent.parent.parent
 GMAIL_CREDS_FILE = ROOT / "google_credentials.json"
@@ -81,6 +84,7 @@ class _AutoSignals(QObject):
     gmail_done = Signal(str, str, str)  # status, detail, icon_color
     drive_auth_done = Signal(str, str)  # auth_text, last_export_text
     drive_op_done = Signal(str)  # result text
+    creds_done = Signal(bool, str)  # ok, detail
 
 
 # ── Status card (reused from setup) ─────────────────────────────────────────
@@ -173,6 +177,16 @@ class AutomationPage(QWidget):
 
         layout.addSpacing(16)
 
+        # ── Garmin Credentials card (Windows only) ────
+        self._creds_card: _SectionCard | None = None
+        if _WINDOWS:
+            self._creds_card = _SectionCard(
+                "Garmin Credentials", "Email and password for automated pulls"
+            )
+            self._creds_card.add_action_button("Configure", self._open_credentials)
+            layout.addWidget(self._creds_card)
+            layout.addSpacing(4)
+
         # ── Gmail MFA card ────────────────────────────
         self._gmail_card = _SectionCard("Gmail MFA", "Automatic MFA code retrieval from Gmail")
         layout.addWidget(self._gmail_card)
@@ -213,11 +227,39 @@ class AutomationPage(QWidget):
         self._signals.gmail_done.connect(self._on_gmail_done)
         self._signals.drive_auth_done.connect(self._on_drive_auth_done)
         self._signals.drive_op_done.connect(self._on_drive_op_done)
+        if _WINDOWS:
+            self._signals.creds_done.connect(self._on_creds_done)
         self.refresh_status()
 
     def refresh_status(self) -> None:
         Thread(target=self._check_gmail, daemon=True).start()
         Thread(target=self._check_drive, daemon=True).start()
+        if _WINDOWS:
+            Thread(target=self._check_creds, daemon=True).start()
+
+    # ── Credentials (Windows only) ────────────────────────────────────────
+
+    def _check_creds(self) -> None:
+        from garmin_extract._credentials import check_credentials
+
+        ok, detail = check_credentials()
+        self._signals.creds_done.emit(ok, detail)
+
+    def _on_creds_done(self, ok: bool, detail: str) -> None:
+        if self._creds_card is None:
+            return
+        import re
+
+        clean = re.sub(r"\[/?[^\]]*\]", "", detail)
+        color = "#a6e3a1" if ok else "#6c7086"
+        self._creds_card.set_status(("\u2713 " if ok else "") + clean, color)
+
+    def _open_credentials(self) -> None:
+        from garmin_extract.gui.screens.setup import CredentialsDialog
+
+        dlg = CredentialsDialog(self)
+        dlg.exec()
+        self.refresh_status()
 
     def _check_gmail(self) -> None:
         status, detail = _check_gmail_automation()

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -63,6 +63,9 @@ def has_display() -> bool:
     return bool(os.environ.get("DISPLAY"))
 
 
+from garmin_extract._browser import detect_windows_browser  # noqa: E402
+
+
 def start_xvfb(display=":99"):
     proc = subprocess.Popen(
         ["Xvfb", display, "-screen", "0", "1280x720x24"],
@@ -668,12 +671,22 @@ def main():
         print("Starting Xvfb...")
         xvfb = start_xvfb()
 
+    browser_bin = None
+    if platform.system() == "Windows":
+        browser_bin = detect_windows_browser()
+        if browser_bin is None:
+            print("ERROR: No supported browser found. Install Chrome, Brave, or Edge and retry.")
+            sys.exit(1)
+
     try:
         print("Launching browser...")
         PROFILE_DIR.mkdir(exist_ok=True)
         # headless=False required — UC mode's uc_open_with_reconnect closes and reopens the
         # Chrome window as part of its Cloudflare bypass; headless mode breaks that mechanism.
-        with SB(uc=True, headless=False, xvfb=False, user_data_dir=str(PROFILE_DIR)) as sb:
+        sb_kwargs = dict(uc=True, headless=False, xvfb=False, user_data_dir=str(PROFILE_DIR))
+        if browser_bin:
+            sb_kwargs["binary_location"] = browser_bin
+        with SB(**sb_kwargs) as sb:
             ensure_logged_in(sb, email, password)
 
             print("Getting display name...")


### PR DESCRIPTION
Closes #56

## Summary

- `garmin_extract/_browser.py` — canonical `detect_windows_browser()` (Chrome → Brave → Edge); `pullers/garmin.py` imports from here
- `gui/app.py` — silent browser check on Windows startup; error dialog + exit if none found
- `gui/main_window.py` — Windows sidebar: Pull Data + Automation only; Linux unchanged
- `gui/screens/automation.py` — Garmin Credentials card at top of Automation page on Windows, wired to existing `CredentialsDialog`

## Test plan

- [ ] Run on Windows — confirm no Initial Setup, Pull Data is landing page, Credentials card present in Automation
- [ ] Run on Linux — confirm Initial Setup still present, no regression
- [ ] Credentials card Configure button opens dialog and saves correctly on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)