### PR TITLE
[cli] Wire Drive/Sheets export to CLI, menu, and cron script

### DIFF
--- a/garmin_extract/cli.py
+++ b/garmin_extract/cli.py
@@ -75,6 +75,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Increase verbosity (stackable: -vv)",
     )
     parser.add_argument(
+        "--push-drive",
+        action="store_true",
+        help="Upload CSV reports to Google Drive (non-interactive, safe for cron)",
+    )
+    parser.add_argument(
+        "--push-sheets",
+        action="store_true",
+        help="Sync CSV reports to Google Sheets (non-interactive, safe for cron)",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
@@ -82,8 +92,38 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _run_export(push_drive: bool, push_sheets: bool) -> None:
+    """Run Drive/Sheets export non-interactively. Exits with 0 on success, 1 on any failure."""
+    from garmin_extract._google_drive import sync_to_sheets, upload_csvs_to_drive
+
+    exit_code = 0
+
+    if push_drive:
+        result = upload_csvs_to_drive()
+        if result["ok"]:
+            names = ", ".join(f["name"] for f in result["files"])
+            print(f"Drive: uploaded {names} → {result['folder_link']}")
+        else:
+            print(f"Drive error: {result['error']}", file=sys.stderr)
+            exit_code = 1
+
+    if push_sheets:
+        result = sync_to_sheets()
+        if result["ok"]:
+            print(f"Sheets: {result['sheet_url']}")
+        else:
+            print(f"Sheets error: {result['error']}", file=sys.stderr)
+            exit_code = 1
+
+    sys.exit(exit_code)
+
+
 def main() -> None:
     args = build_parser().parse_args()
+
+    if args.push_drive or args.push_sheets:
+        _run_export(push_drive=args.push_drive, push_sheets=args.push_sheets)
+        return  # _run_export calls sys.exit; this is a safety return
 
     if args.no_tui:
         from garmin_extract.menu import main as run_menu

--- a/garmin_extract/menu.py
+++ b/garmin_extract/menu.py
@@ -759,6 +759,76 @@ def build_csvs() -> None:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# 7. Drive / Sheets export
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _run_drive_export(drive: bool, sheets: bool) -> None:
+    """Shared runner for Drive/Sheets export — prints results inline."""
+    from garmin_extract._google_drive import sync_to_sheets, upload_csvs_to_drive
+
+    if drive:
+        print("  Uploading CSVs to Google Drive...")
+        result = upload_csvs_to_drive()
+        if result["ok"]:
+            names = ", ".join(f["name"] for f in result["files"])
+            console.print(f"  [green]✓[/]  Uploaded: {names}")
+            console.print(f"  [dim]  {result['folder_link']}[/]")
+        else:
+            console.print(f"  [red]✗[/]  Drive error: {result['error']}")
+
+    if sheets:
+        print("  Syncing to Google Sheets...")
+        result = sync_to_sheets()
+        if result["ok"]:
+            console.print("  [green]✓[/]  Sheet updated.")
+            console.print(f"  [dim]  {result['sheet_url']}[/]")
+        else:
+            console.print(f"  [red]✗[/]  Sheets error: {result['error']}")
+
+
+def push_to_drive() -> None:
+    header("Upload to Google Drive")
+    print("  Uploads garmin_daily.csv and garmin_activities.csv to")
+    print("  a 'Garmin Extract' folder in your Google Drive.\n")
+    go = prompt_with_navigation("  Upload now? [Y/n]: ")
+    if go.lower() == "n":
+        print("  Cancelled.")
+        _continue()
+        return
+    print()
+    _run_drive_export(drive=True, sheets=False)
+    _continue()
+
+
+def push_to_sheets() -> None:
+    header("Sync to Google Sheets")
+    print("  Creates or updates a 'Garmin Data' Google Sheet with")
+    print("  Daily and Activities tabs.\n")
+    go = prompt_with_navigation("  Sync now? [Y/n]: ")
+    if go.lower() == "n":
+        print("  Cancelled.")
+        _continue()
+        return
+    print()
+    _run_drive_export(drive=False, sheets=True)
+    _continue()
+
+
+def push_to_both() -> None:
+    header("Upload to Drive + Sync Sheets")
+    print("  Uploads CSVs to Drive and updates the Google Sheet.\n")
+    go = prompt_with_navigation("  Run both now? [Y/n]: ")
+    if go.lower() == "n":
+        print("  Cancelled.")
+        _continue()
+        return
+    print()
+    _run_drive_export(drive=True, sheets=True)
+    _continue()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Menu rendering
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -841,6 +911,10 @@ def menu_automation() -> None:
         [
             ("", "─── Unattended MFA ─────────────────────────────────", None),
             ("1", "Set up Gmail MFA  (auto-handle Garmin security codes)", setup_gmail_mfa),
+            ("", "─── Google Drive / Sheets ───────────────────────────", None),
+            ("2", "Upload CSVs to Google Drive", push_to_drive),
+            ("3", "Sync to Google Sheets", push_to_sheets),
+            ("4", "Upload to Drive + Sync Sheets", push_to_both),
         ],
     )
 

--- a/scripts/pull-garmin.sh
+++ b/scripts/pull-garmin.sh
@@ -4,12 +4,31 @@
 #
 # Cron example (6 AM daily):
 #   0 6 * * * /path/to/garmin-extract/scripts/pull-garmin.sh
+#
+# Optional flags (can be combined):
+#   --push-drive    Upload CSVs to Google Drive after a successful pull
+#   --push-sheets   Sync CSVs to Google Sheets after a successful pull
+#   --push-both     Shorthand for --push-drive --push-sheets
+#
+# Example with Drive + Sheets:
+#   0 6 * * * /path/to/garmin-extract/scripts/pull-garmin.sh --push-both
 
 set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PYTHON="${PROJECT_DIR}/.venv/bin/python"
 LOG="/tmp/garmin-pull.log"
+
+PUSH_DRIVE=0
+PUSH_SHEETS=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --push-drive)  PUSH_DRIVE=1 ;;
+        --push-sheets) PUSH_SHEETS=1 ;;
+        --push-both)   PUSH_DRIVE=1; PUSH_SHEETS=1 ;;
+    esac
+done
 
 echo "=== $(date '+%Y-%m-%d %H:%M:%S') ===" >> "$LOG"
 cd "$PROJECT_DIR"
@@ -20,4 +39,14 @@ echo "Pull exit: $PULL_EXIT" >> "$LOG"
 if [ "$PULL_EXIT" -eq 0 ]; then
     "$PYTHON" reports/build_garmin_csvs.py >> "$LOG" 2>&1
     echo "CSV build exit: $?" >> "$LOG"
+
+    if [ "$PUSH_DRIVE" -eq 1 ]; then
+        "$PYTHON" -m garmin_extract --push-drive >> "$LOG" 2>&1
+        echo "Drive push exit: $?" >> "$LOG"
+    fi
+
+    if [ "$PUSH_SHEETS" -eq 1 ]; then
+        "$PYTHON" -m garmin_extract --push-sheets >> "$LOG" 2>&1
+        echo "Sheets push exit: $?" >> "$LOG"
+    fi
 fi


### PR DESCRIPTION
Closes #58

## Summary

- `cli.py` — `--push-drive` and `--push-sheets` flags; bypass TUI/GUI entirely, call export functions directly, print Drive folder URL or Sheet URL on success, exit 1 on failure. Combinable: `garmin-extract --push-drive --push-sheets`
- `menu.py` — Drive/Sheets section added to Automation menu: Upload to Drive (2), Sync to Sheets (3), Both (4)
- `pull-garmin.sh` — accepts `--push-drive`, `--push-sheets`, `--push-both`; export runs after successful pull + CSV rebuild, all logged

## Test plan

- [ ] `garmin-extract --push-drive` — uploads CSVs, prints Drive folder URL, exits 0
- [ ] `garmin-extract --push-sheets` — syncs sheet, prints Sheet URL, exits 0
- [ ] `garmin-extract --push-drive --push-sheets` — runs both in one invocation
- [ ] Run with missing OAuth token — clean error to stderr, exits 1
- [ ] `pull-garmin.sh --push-both` — verify log entries for pull, CSV build, Drive, Sheets
- [ ] Print menu Automation → options 2/3/4 present and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)