### PR TITLE
[gui] Pull Data: Latest Sync header with staleness indicator (#62)

### DIFF
--- a/garmin_extract/gui/screens/pull_data.py
+++ b/garmin_extract/gui/screens/pull_data.py
@@ -58,6 +58,26 @@ def _find_fetch_new_range() -> tuple[str, int] | None:
     return start.isoformat(), (yesterday - start).days + 1
 
 
+def _get_latest_sync_status() -> tuple[str, int] | None:
+    """Returns (latest_iso, days_behind). None if no local data.
+
+    days_behind is 0 when latest ≥ yesterday (in sync), otherwise the
+    count of days between the latest local record and yesterday.
+    """
+    import re
+
+    data_dir = Path(__file__).parent.parent.parent.parent / "data" / "garmin"
+    if not data_dir.exists():
+        return None
+    date_re = re.compile(r"^\d{4}-\d{2}-\d{2}\.json$")
+    dates = sorted(f.stem for f in data_dir.glob("*.json") if date_re.match(f.name))
+    if not dates:
+        return None
+    latest = date.fromisoformat(dates[-1])
+    yesterday = date.today() - timedelta(days=1)
+    return dates[-1], max(0, (yesterday - latest).days)
+
+
 # ── Section header widget ────────────────────────────────────────────────────
 
 
@@ -70,6 +90,44 @@ class _SectionHeader(QLabel):
             "font-size: 12px; font-weight: bold; color: #6c7086;"
             " letter-spacing: 1px; background: transparent;"
             " border-bottom: 1px solid #45475a; padding-bottom: 4px;"
+        )
+
+
+# ── Latest Sync card ─────────────────────────────────────────────────────────
+
+
+class _LatestSyncCard(QWidget):
+    """Shows the most recent local data date and staleness. Call refresh()
+    after a pull to update."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+        layout.addWidget(_SectionHeader("LATEST SYNC"))
+        self._status = QLabel()
+        self._status.setWordWrap(True)
+        layout.addWidget(self._status)
+        self.refresh()
+
+    def refresh(self) -> None:
+        result = _get_latest_sync_status()
+        if result is None:
+            text = "No local data — run Fetch new to start"
+            color = "#f9e2af"
+        else:
+            date_iso, days = result
+            if days == 0:
+                text = f"{date_iso}  (up to date)"
+                color = "#a6e3a1"
+            else:
+                word = "day" if days == 1 else "days"
+                text = f"{date_iso}  ({days} {word} out of sync)"
+                color = "#f9e2af"
+        self._status.setText(text)
+        self._status.setStyleSheet(
+            f"font-size: 14px; color: {color}; background: transparent; padding: 6px 0 4px 0;"
         )
 
 
@@ -211,6 +269,12 @@ class PullDataPage(QWidget):
 
         layout.addSpacing(16)
 
+        # ── LATEST SYNC ───────────────────────────────
+        self._latest_sync = _LatestSyncCard()
+        layout.addWidget(self._latest_sync)
+
+        layout.addSpacing(8)
+
         # ── SYNC ──────────────────────────────────────
         layout.addWidget(_SectionHeader("SYNC"))
         btn = _ActionButton("Fetch new", "pull all dates not yet in local data")
@@ -279,6 +343,7 @@ class PullDataPage(QWidget):
             parent=self,
         )
         dlg.exec()
+        self._latest_sync.refresh()
 
     def _fetch_new(self) -> None:
         try:


### PR DESCRIPTION
## Summary

- Adds a **LATEST SYNC** section at the top of the Pull Data screen
- Shows most recent local data date + days-behind count
- Green "(up to date)" when latest ≥ yesterday, amber "(N days out of sync)" when stale
- Empty state: "No local data — run Fetch new to start"
- Refreshes in place after any pull completes

Closes #62

## Test plan

- [ ] Fresh install (no \`data/garmin/\`) → empty-state message shown
- [ ] Pull a stale date range (e.g. 30 days ago only) → shows correct staleness count
- [ ] Run Fetch new → section refreshes to "(up to date)" after completion without app restart
- [ ] Verify color coding: green when in sync, amber when stale/empty
- [ ] Singular/plural copy: "1 day" vs "2 days"

🤖 Generated with [Claude Code](https://claude.com/claude-code)