### PR TITLE
[gui] Fix Latest Sync label clipped on first paint (#67)

### DIFF
--- a/garmin_extract/gui/screens/pull_data.py
+++ b/garmin_extract/gui/screens/pull_data.py
@@ -107,7 +107,6 @@ class _LatestSyncCard(QWidget):
         layout.setSpacing(4)
         layout.addWidget(_SectionHeader("LATEST SYNC"))
         self._status = QLabel()
-        self._status.setWordWrap(True)
         layout.addWidget(self._status)
         self.refresh()
 

--- a/garmin_extract/gui/screens/pull_data.py
+++ b/garmin_extract/gui/screens/pull_data.py
@@ -104,10 +104,11 @@ class _LatestSyncCard(QWidget):
         super().__init__(parent)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(4)
+        layout.setSpacing(6)
         layout.addWidget(_SectionHeader("LATEST SYNC"))
         self._status = QLabel()
         layout.addWidget(self._status)
+        layout.addSpacing(4)
         self.refresh()
 
     def refresh(self) -> None:
@@ -125,9 +126,7 @@ class _LatestSyncCard(QWidget):
                 text = f"{date_iso}  ({days} {word} out of sync)"
                 color = "#f9e2af"
         self._status.setText(text)
-        self._status.setStyleSheet(
-            f"font-size: 14px; color: {color}; background: transparent; padding: 6px 0 4px 0;"
-        )
+        self._status.setStyleSheet(f"font-size: 14px; color: {color}; background: transparent;")
 
 
 # ── Action button widget ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Removes \`setWordWrap(True)\` from the \`_LatestSyncCard\` status label
- Root cause: Qt's word-wrap sizing is lazy and miscalculated label height on first paint, clipping the text until a resize event triggered relayout
- All status messages are short single lines, so word wrap was unnecessary

Closes #67

## Test plan

- [ ] Fresh launch on Windows — Latest Sync line fully visible on first paint
- [ ] Resize window — text remains intact
- [ ] All three states (empty / in sync / stale) render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)