### PR TITLE
[windows] Scheduled Pulls via Task Scheduler (#31)

### DIFF
--- a/garmin_extract/_windows_scheduler.py
+++ b/garmin_extract/_windows_scheduler.py
@@ -1,0 +1,139 @@
+"""Windows Task Scheduler integration via the `schtasks` CLI.
+
+This module manages a single daily scheduled task named `TASK_NAME` that
+runs `garmin-extract --pull` at a user-chosen time. Supports optional
+--push-drive / --push-sheets flags for combined pull + export.
+
+All functions return (ok, detail) tuples. None of them raise.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+TASK_NAME = "garmin-extract-daily"
+
+
+def _build_command(push_drive: bool, push_sheets: bool) -> str:
+    """Return the command string that Task Scheduler will run.
+
+    Frozen build: `"C:\\path\\to\\garmin-extract.exe" --pull [...]`
+    Source mode: `"C:\\path\\to\\venv\\Scripts\\python.exe" -m garmin_extract --pull [...]`
+    """
+    exe = str(Path(sys.executable).resolve())
+    parts = [f'"{exe}"']
+    if not getattr(sys, "frozen", False):
+        parts += ["-m", "garmin_extract"]
+    parts.append("--pull")
+    if push_drive:
+        parts.append("--push-drive")
+    if push_sheets:
+        parts.append("--push-sheets")
+    return " ".join(parts)
+
+
+def get_task_status() -> dict:
+    """Return the current state of the scheduled task.
+
+    Returns a dict with keys:
+      - installed: bool
+      - next_run_time: str | None  (raw from schtasks)
+      - start_time: str | None     (HH:MM from Start Time field)
+      - task_to_run: str | None    (the command line)
+      - raw: str                   (full schtasks output for debugging)
+    """
+    result = {
+        "installed": False,
+        "next_run_time": None,
+        "start_time": None,
+        "task_to_run": None,
+        "raw": "",
+    }
+    try:
+        proc = subprocess.run(
+            ["schtasks", "/query", "/tn", TASK_NAME, "/fo", "LIST", "/v"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return result
+
+    result["raw"] = proc.stdout + proc.stderr
+    if proc.returncode != 0:
+        return result
+
+    result["installed"] = True
+    for line in proc.stdout.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if key == "Next Run Time":
+            result["next_run_time"] = value
+        elif key == "Start Time":
+            result["start_time"] = value
+        elif key == "Task To Run":
+            result["task_to_run"] = value
+    return result
+
+
+def create_or_update_task(
+    hour: int, minute: int, push_drive: bool, push_sheets: bool
+) -> tuple[bool, str]:
+    """Create or overwrite the daily scheduled task.
+
+    `hour` 0-23, `minute` 0-59. Runs daily at that local time.
+    """
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        return False, f"Invalid time: {hour:02d}:{minute:02d}"
+
+    cmd = [
+        "schtasks",
+        "/create",
+        "/tn",
+        TASK_NAME,
+        "/tr",
+        _build_command(push_drive, push_sheets),
+        "/sc",
+        "daily",
+        "/st",
+        f"{hour:02d}:{minute:02d}",
+        "/f",  # force overwrite if it already exists
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+    except FileNotFoundError:
+        return False, "schtasks not found — are you on Windows?"
+
+    if proc.returncode == 0:
+        return True, f"Scheduled daily at {hour:02d}:{minute:02d}"
+    return False, (proc.stderr or proc.stdout).strip() or f"schtasks exit {proc.returncode}"
+
+
+def delete_task() -> tuple[bool, str]:
+    """Remove the scheduled task. No-op if not installed."""
+    try:
+        proc = subprocess.run(
+            ["schtasks", "/delete", "/tn", TASK_NAME, "/f"],
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return False, "schtasks not found — are you on Windows?"
+
+    if proc.returncode == 0:
+        return True, "Scheduled task removed"
+    # `schtasks /delete` exits non-zero if the task doesn't exist — treat as success
+    combined = (proc.stderr + proc.stdout).lower()
+    if "cannot find" in combined or "does not exist" in combined:
+        return True, "No scheduled task to remove"
+    return False, (proc.stderr or proc.stdout).strip() or f"schtasks exit {proc.returncode}"
+
+
+def parse_flags_from_command(cmd: str) -> tuple[bool, bool]:
+    """Given a stored `task_to_run` string, return (push_drive, push_sheets)."""
+    lowered = cmd.lower()
+    return "--push-drive" in lowered, "--push-sheets" in lowered

--- a/garmin_extract/cli.py
+++ b/garmin_extract/cli.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from datetime import datetime
 
 from garmin_extract import __version__
 
@@ -76,6 +77,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Increase verbosity (stackable: -vv)",
     )
     parser.add_argument(
+        "--pull",
+        action="store_true",
+        help=(
+            "Pull yesterday's data, rebuild CSVs, and optionally push to "
+            "Drive/Sheets. Non-interactive — safe for cron and Task Scheduler."
+        ),
+    )
+    parser.add_argument(
         "--push-drive",
         action="store_true",
         help="Upload CSV reports to Google Drive (non-interactive, safe for cron)",
@@ -119,8 +128,45 @@ def _run_export(push_drive: bool, push_sheets: bool) -> None:
     sys.exit(exit_code)
 
 
+def _run_scheduled_pull(push_drive: bool, push_sheets: bool) -> None:
+    """Run the full scheduled-pull sequence: pull yesterday, build CSVs, optional export.
+
+    Mirrors scripts/pull-garmin.sh for Windows Task Scheduler. Exits 0 if every
+    stage succeeds, 1 on any failure.
+    """
+    import subprocess
+
+    from garmin_extract._paths import app_root, bundle_root
+
+    scripts_root = bundle_root()
+    cwd = str(app_root())
+    puller = str(scripts_root / "pullers" / "garmin.py")
+    csv_builder = str(scripts_root / "reports" / "build_garmin_csvs.py")
+
+    print(f"[pull] {datetime.now().isoformat(timespec='seconds')}", flush=True)
+    pull = subprocess.run([sys.executable, "-u", puller], cwd=cwd)
+    if pull.returncode != 0:
+        print(f"Pull failed (exit {pull.returncode})", file=sys.stderr)
+        sys.exit(1)
+
+    csv = subprocess.run([sys.executable, "-u", csv_builder], cwd=cwd)
+    if csv.returncode != 0:
+        print(f"CSV build failed (exit {csv.returncode})", file=sys.stderr)
+        sys.exit(1)
+
+    if push_drive or push_sheets:
+        _run_export(push_drive=push_drive, push_sheets=push_sheets)
+        return  # _run_export calls sys.exit
+
+    sys.exit(0)
+
+
 def main() -> None:
     args = build_parser().parse_args()
+
+    if args.pull:
+        _run_scheduled_pull(push_drive=args.push_drive, push_sheets=args.push_sheets)
+        return  # _run_scheduled_pull calls sys.exit
 
     if args.push_drive or args.push_sheets:
         _run_export(push_drive=args.push_drive, push_sheets=args.push_sheets)

--- a/garmin_extract/gui/screens/automation.py
+++ b/garmin_extract/gui/screens/automation.py
@@ -8,9 +8,10 @@ import shutil
 from pathlib import Path
 from threading import Thread
 
-from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtCore import QObject, Qt, QTime, Signal
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
+    QCheckBox,
     QDialog,
     QFileDialog,
     QFrame,
@@ -18,6 +19,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QTimeEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -90,6 +92,7 @@ class _AutoSignals(QObject):
     drive_auth_done = Signal(str, str)  # auth_text, last_export_text
     drive_op_done = Signal(str)  # result text
     creds_done = Signal(bool, str)  # ok, detail
+    sched_done = Signal(bool, str)  # installed, detail
 
 
 # ── Status card (reused from setup) ─────────────────────────────────────────
@@ -389,6 +392,135 @@ class _GmailSetupDialog(QDialog):
             self._show_error(f"Token exchange failed: {detail}")
 
 
+# ── Scheduled Pulls dialog ───────────────────────────────────────────────────
+
+
+class _ScheduledPullsDialog(QDialog):
+    """Configure a daily Windows Task Scheduler entry that runs a pull at a
+    user-chosen time, optionally followed by Drive/Sheets export.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Scheduled Pulls")
+        self.setMinimumWidth(480)
+        self.setModal(True)
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(10)
+
+        intro = QLabel(
+            "Schedule a daily pull via Windows Task Scheduler. The task runs "
+            "garmin-extract with --pull at the time you choose."
+        )
+        intro.setWordWrap(True)
+        intro.setStyleSheet("color: #6c7086;")
+        layout.addWidget(intro)
+
+        self._status = QLabel("Checking current schedule…")
+        self._status.setStyleSheet("color: #cdd6f4; margin-top: 4px;")
+        layout.addWidget(self._status)
+
+        # ── Time picker ──
+        time_row = QHBoxLayout()
+        time_row.addWidget(QLabel("Run daily at"))
+        self._time_edit = QTimeEdit()
+        self._time_edit.setDisplayFormat("HH:mm")
+        self._time_edit.setTime(QTime(6, 0))
+        time_row.addWidget(self._time_edit)
+        time_row.addStretch()
+        layout.addLayout(time_row)
+
+        # ── Export toggles ──
+        self._push_drive = QCheckBox("Upload CSVs to Google Drive after pull")
+        layout.addWidget(self._push_drive)
+
+        self._push_sheets = QCheckBox("Sync CSVs to Google Sheets after pull")
+        layout.addWidget(self._push_sheets)
+
+        self._error = QLabel()
+        self._error.setWordWrap(True)
+        self._error.hide()
+        layout.addWidget(self._error)
+
+        # ── Buttons ──
+        btn_row = QHBoxLayout()
+        self._disable_btn = QPushButton("Disable")
+        self._disable_btn.clicked.connect(self._on_disable)
+        self._disable_btn.setEnabled(False)
+        btn_row.addWidget(self._disable_btn)
+        btn_row.addStretch()
+        cancel = QPushButton("Cancel")
+        cancel.clicked.connect(self.reject)
+        btn_row.addWidget(cancel)
+        self._save_btn = QPushButton("Save")
+        self._save_btn.setDefault(True)
+        self._save_btn.clicked.connect(self._on_save)
+        btn_row.addWidget(self._save_btn)
+        layout.addLayout(btn_row)
+
+        self._load_current_state()
+
+    def _load_current_state(self) -> None:
+        from garmin_extract._windows_scheduler import get_task_status, parse_flags_from_command
+
+        state = get_task_status()
+        if not state["installed"]:
+            self._status.setText("Not yet scheduled — pick a time and click Save.")
+            self._status.setStyleSheet("color: #f9e2af;")
+            return
+
+        start = state.get("start_time") or ""
+        next_run = state.get("next_run_time") or ""
+        self._status.setText(
+            f"✓ Scheduled daily at {start}" + (f"  (next run: {next_run})" if next_run else "")
+        )
+        self._status.setStyleSheet("color: #a6e3a1;")
+        self._disable_btn.setEnabled(True)
+
+        # Pre-fill time + flags from the installed task
+        try:
+            hh, mm = start.split(":", 1)[0:2] if ":" in start else ("6", "0")
+            hh_int, mm_int = int(hh[:2]), int(mm[:2])
+            self._time_edit.setTime(QTime(hh_int, mm_int))
+        except Exception:
+            pass
+        cmd = state.get("task_to_run") or ""
+        if cmd:
+            drive, sheets = parse_flags_from_command(cmd)
+            self._push_drive.setChecked(drive)
+            self._push_sheets.setChecked(sheets)
+
+    def _show_error(self, msg: str) -> None:
+        self._error.setText(msg)
+        self._error.setStyleSheet("color: #f38ba8;")
+        self._error.show()
+
+    def _on_save(self) -> None:
+        from garmin_extract._windows_scheduler import create_or_update_task
+
+        t = self._time_edit.time()
+        ok, detail = create_or_update_task(
+            hour=t.hour(),
+            minute=t.minute(),
+            push_drive=self._push_drive.isChecked(),
+            push_sheets=self._push_sheets.isChecked(),
+        )
+        if ok:
+            self.accept()
+        else:
+            self._show_error(f"Could not schedule: {detail}")
+
+    def _on_disable(self) -> None:
+        from garmin_extract._windows_scheduler import delete_task
+
+        ok, detail = delete_task()
+        if ok:
+            self.accept()
+        else:
+            self._show_error(f"Could not remove scheduled task: {detail}")
+
+
 # ── Automation page ──────────────────────────────────────────────────────────
 
 
@@ -432,9 +564,12 @@ class AutomationPage(QWidget):
         # ── Scheduled Pulls card ──────────────────────
         self._sched_card = _SectionCard(
             "Scheduled Pulls",
-            "Windows Task Scheduler — coming in issue #31",
+            "Run a daily pull automatically via Windows Task Scheduler",
         )
-        self._sched_card.set_status("Not yet implemented", "#6c7086")
+        if _WINDOWS:
+            self._sched_card.add_action_button("Configure", self._open_scheduled_pulls)
+        else:
+            self._sched_card.set_status("Available on Windows only", "#6c7086")
         layout.addWidget(self._sched_card)
 
         layout.addSpacing(4)
@@ -465,6 +600,7 @@ class AutomationPage(QWidget):
         self._signals.drive_op_done.connect(self._on_drive_op_done)
         if _WINDOWS:
             self._signals.creds_done.connect(self._on_creds_done)
+            self._signals.sched_done.connect(self._on_sched_done)
         self.refresh_status()
 
     def refresh_status(self) -> None:
@@ -472,6 +608,7 @@ class AutomationPage(QWidget):
         Thread(target=self._check_drive, daemon=True).start()
         if _WINDOWS:
             Thread(target=self._check_creds, daemon=True).start()
+            Thread(target=self._check_sched, daemon=True).start()
 
     # ── Credentials (Windows only) ────────────────────────────────────────
 
@@ -499,6 +636,30 @@ class AutomationPage(QWidget):
 
     def _open_gmail_setup(self) -> None:
         dlg = _GmailSetupDialog(self)
+        dlg.exec()
+        self.refresh_status()
+
+    # ── Scheduled Pulls (Windows only) ───────────────────────────────────
+
+    def _check_sched(self) -> None:
+        from garmin_extract._windows_scheduler import get_task_status
+
+        state = get_task_status()
+        if state["installed"]:
+            start = state.get("start_time") or ""
+            detail = f"Scheduled daily at {start}" if start else "Scheduled"
+            self._signals.sched_done.emit(True, detail)
+        else:
+            self._signals.sched_done.emit(False, "Not scheduled")
+
+    def _on_sched_done(self, installed: bool, detail: str) -> None:
+        if installed:
+            self._sched_card.set_status("\u2713 " + detail, "#a6e3a1")
+        else:
+            self._sched_card.set_status(detail, "#6c7086")
+
+    def _open_scheduled_pulls(self) -> None:
+        dlg = _ScheduledPullsDialog(self)
         dlg.exec()
         self.refresh_status()
 

--- a/garmin_extract/gui/screens/automation.py
+++ b/garmin_extract/gui/screens/automation.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QScrollArea,
     QTimeEdit,
     QVBoxLayout,
     QWidget,
@@ -139,6 +140,7 @@ class _SectionCard(QFrame):
     def add_action_button(self, label: str, callback: object) -> QPushButton:
         btn = QPushButton(label)
         btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        btn.setMinimumHeight(32)
         btn.setStyleSheet("""
             QPushButton {
                 padding: 6px 14px;
@@ -530,7 +532,22 @@ class AutomationPage(QWidget):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
-        layout = QVBoxLayout(self)
+        # Wrap content in a scroll area so the page gracefully scrolls when
+        # cards + buttons exceed the viewport height instead of compressing.
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        scroll.setStyleSheet("QScrollArea { background: transparent; border: none; }")
+        outer.addWidget(scroll)
+
+        content = QWidget()
+        scroll.setWidget(content)
+
+        layout = QVBoxLayout(content)
         layout.setContentsMargins(40, 32, 40, 32)
         layout.setSpacing(8)
 


### PR DESCRIPTION
## Summary

Implements daily pull scheduling on Windows through the \`schtasks\` CLI, mirroring the \`scripts/pull-garmin.sh\` cron flow on Linux.

### Changes

- **\`cli.py\`** — new \`--pull\` flag runs pull-yesterday → build CSVs → optional \`--push-drive\` / \`--push-sheets\`. Non-interactive, exits 0/1, safe for cron and Task Scheduler.
- **\`_windows_scheduler.py\`** (new) — schtasks wrappers: \`get_task_status()\`, \`create_or_update_task()\`, \`delete_task()\`, \`parse_flags_from_command()\`. Auto-detects frozen vs source mode for the command string.
- **\`automation.py\`** — new \`_ScheduledPullsDialog\` with QTimeEdit picker and Drive/Sheets checkboxes; wires Configure button on the Scheduled Pulls card (Windows only); card status shows the current schedule on mount.

### Scheduled command at runtime

- Frozen build: \`"C:\\path\\to\\garmin-extract.exe" --pull [--push-drive] [--push-sheets]\`
- Source mode: \`"C:\\path\\to\\venv\\Scripts\\python.exe" -m garmin_extract --pull [...]\`

Closes #31

## Test plan

- [ ] Automation → Scheduled Pulls → Configure — dialog opens with "Not yet scheduled"
- [ ] Pick a time (e.g. 06:00), no checkboxes, click Save — dialog closes, card flips to "✓ Scheduled daily at 06:00"
- [ ] Verify in Windows Task Scheduler UI that \`garmin-extract-daily\` exists with the right command and trigger
- [ ] Reopen dialog — time is pre-filled with 06:00, Disable button enabled
- [ ] Tick Drive + Sheets, change time to 07:15, Save — task updates in-place (no duplicate)
- [ ] Reopen dialog — checkboxes reflect the stored flags
- [ ] Click Disable — task is removed, card flips back to "Not scheduled"
- [ ] \`garmin-extract --pull\` from a terminal — runs pull → CSV build, exits 0
- [ ] \`garmin-extract --pull --push-drive\` — also uploads to Drive after successful pull

🤖 Generated with [Claude Code](https://claude.com/claude-code)