### PR TITLE
[fix] Auto-login resilience: probe before racing, clean error surfacing (#64)

### DIFF
--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -91,7 +91,7 @@ def wait_for_mfa() -> str:
             print("MFA REQUIRED — polling Gmail automatically...")
             code = wait_for_mfa_gmail(timeout=300)
             if code:
-                print(f"MFA code retrieved from Gmail: {code}")
+                print("MFA obtained.")
                 return code
             print("Gmail poll failed or timed out — falling back to manual entry.")
     except ImportError:

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -172,6 +172,30 @@ def _wait_for_manual_login(sb) -> None:
     sys.exit(1)
 
 
+def _probe_email_field(sb) -> tuple[bool, str]:
+    """Check whether it's safe to auto-type credentials.
+
+    Returns (ready, reason). Ready means the #email field is present,
+    empty, and we are still on the sign-in page. Anything else means
+    the user (or Garmin) has already moved past the state we expect.
+    """
+    url = sb.get_current_url()
+    if "sign-in" not in url and "sso.garmin.com" not in url:
+        return False, f"already past sign-in page ({url[:80]})"
+    try:
+        if not sb.is_element_present("#email"):
+            return False, "email field not present (DOM may have changed)"
+    except Exception as exc:
+        return False, f"could not probe email field: {exc}"
+    try:
+        existing = sb.get_value("#email") or ""
+    except Exception:
+        existing = ""
+    if existing.strip():
+        return False, "user has already started entering credentials"
+    return True, ""
+
+
 def _do_login(sb, email: str, password: str) -> None:
     sb.uc_open_with_reconnect(
         "https://sso.garmin.com/portal/sso/en-US/sign-in"
@@ -179,6 +203,13 @@ def _do_login(sb, email: str, password: str) -> None:
         reconnect_time=6,
     )
     sb.sleep(5)
+
+    ready, reason = _probe_email_field(sb)
+    if not ready:
+        print(f"Auto-login skipped: {reason}")
+        print("Handing off to manual login — complete the sign-in in the browser.")
+        _wait_for_manual_login(sb)
+        return
 
     sb.type("#email", email)
     sb.type("#password", password)
@@ -687,7 +718,24 @@ def main():
         if browser_bin:
             sb_kwargs["binary_location"] = browser_bin
         with SB(**sb_kwargs) as sb:
-            ensure_logged_in(sb, email, password)
+            try:
+                ensure_logged_in(sb, email, password)
+            except Exception as exc:
+                shot = Path(tempfile.gettempdir()) / "garmin_login_failure.png"
+                try:
+                    sb.save_screenshot(str(shot))
+                except Exception:
+                    shot = None
+                msg = str(exc).splitlines()[0] if str(exc) else type(exc).__name__
+                print(f"ERROR: Login failed — {msg}", file=sys.stderr)
+                if shot:
+                    print(f"Screenshot: {shot}", file=sys.stderr)
+                print(
+                    "If auto-login keeps racing the browser, clear saved credentials and use "
+                    "manual login from the 'Configure auto login' dialog.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
 
             print("Getting display name...")
             display_name, uuid = get_display_name(sb)


### PR DESCRIPTION
## Summary

Two-layer defense against the auto-login crash reported in #64, where \`sb.type(\"#email\", email)\` raised \`NoSuchElementException\` after 10s when the user had already started typing manually.

### 1. Probe before racing

New \`_probe_email_field(sb)\` helper returns \`(ready, reason)\` after checking:
- We're still on the sign-in page (URL match)
- \`#email\` selector is present in the DOM
- The field is empty (user hasn't started typing)

If any check fails, \`_do_login\` prints a clear reason line and hands off to \`_wait_for_manual_login\` — graceful fallback instead of a 10-second blind wait followed by a crash.

### 2. Clean error surfacing

\`ensure_logged_in()\` is now wrapped in a top-level try/except inside \`main()\`. On any exception (selenium or otherwise):
- Saves a failure screenshot to the temp dir
- Prints a single-line readable error to stderr
- Hints the user to clear creds and use manual login if races keep happening
- Exits 1 cleanly — no raw Python traceback in the GUI log panel

Closes #64

## Test plan

- [ ] Happy path: saved creds, hands off keyboard — auto-login completes as before
- [ ] Race path: trigger Fetch new, type into the browser manually before auto-login fires — should log \"Auto-login skipped: user has already started entering credentials\" and hand off to manual wait (no crash)
- [ ] Slow-load path: if the page hasn't rendered \`#email\` yet, should log \"email field not present (DOM may have changed)\" and hand off to manual wait
- [ ] Malformed page path: simulate by navigating away (or CF challenge) — should log \"already past sign-in page\" and hand off
- [ ] If a selenium exception does occur later in the login flow, verify stderr shows a one-line message and screenshot path — not a full traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)