### PR TITLE
feat(linux): first-run preflight — Xvfb, creds, Gmail MFA (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" \
     | sudo tee /etc/apt/sources.list.d/google-chrome.list
 sudo apt update && sudo apt install -y google-chrome-stable
 
-# Install Xvfb (virtual display — required for headless Chrome)
-sudo apt install -y xvfb
-
 # Install garmin-extract
 git clone https://github.com/ColonelPanicX/garmin-extract.git
 cd garmin-extract
@@ -62,7 +59,7 @@ uv sync
 uv run python -m garmin_extract
 ```
 
-The app auto-starts Xvfb when needed, but the `xvfb` binary must be installed first.
+On first launch, the TUI detects headless Linux and walks you through the remaining prerequisites (Xvfb install, Garmin credentials, Gmail MFA). Because there's no display for a manual login, **all three must be configured** before a pull can run — the preflight gates the **Continue** button until everything is green. The TUI can install Xvfb on apt/dnf/pacman/apk systems; on unrecognized distros, install `xvfb` (or your distro's equivalent) manually.
 
 ## First-time setup
 

--- a/garmin_extract/_credentials.py
+++ b/garmin_extract/_credentials.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from garmin_extract._paths import app_root
 
 _SERVICE = "garmin-extract"
@@ -76,13 +78,24 @@ def save_to_keyring(email: str, password: str) -> tuple[bool, str]:
 
 
 def save_to_env(email: str, password: str) -> None:
-    """Write credentials to .env (plaintext)."""
+    """Write credentials to .env (plaintext). Sets 0600 perms on POSIX."""
     lines = [
         "# Garmin Connect credentials",
         f"GARMIN_EMAIL={email}",
         f"GARMIN_PASSWORD={password}",
     ]
     ENV_FILE.write_text("\n".join(lines) + "\n")
+    _lock_down_env(ENV_FILE)
+
+
+def _lock_down_env(path) -> None:
+    """chmod 600 on POSIX so the .env is only readable by the owning user."""
+    if os.name != "posix":
+        return
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
 
 
 def check_credentials() -> tuple[bool, str]:
@@ -153,6 +166,7 @@ def _scrub_env() -> None:
         ENV_FILE.unlink()
     else:
         ENV_FILE.write_text("\n".join(kept) + "\n")
+        _lock_down_env(ENV_FILE)
 
 
 def _load_from_env() -> tuple[str, str]:

--- a/garmin_extract/_xvfb.py
+++ b/garmin_extract/_xvfb.py
@@ -1,0 +1,69 @@
+"""Xvfb detection and install helpers — shared across menu, TUI setup, and CLI.
+
+The "truly headless" check is cached at first call so that later callers still
+see the original state after Xvfb has exported DISPLAY into the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+_OS_RELEASE = Path("/etc/os-release")
+_truly_headless: bool | None = None
+
+
+def is_installed() -> bool:
+    return shutil.which("Xvfb") is not None
+
+
+def is_truly_headless() -> bool:
+    """True when we started on Linux with no $DISPLAY — cached for the process lifetime."""
+    global _truly_headless
+    if _truly_headless is None:
+        _truly_headless = platform.system() == "Linux" and not os.environ.get("DISPLAY")
+    return _truly_headless
+
+
+def detect_install_cmd() -> tuple[list[str], str]:
+    """Return (argv, human-readable string) for installing Xvfb on this distro."""
+    ids: set[str] = set()
+    if _OS_RELEASE.exists():
+        for line in _OS_RELEASE.read_text().splitlines():
+            if "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            v = v.strip().strip('"')
+            if k == "ID":
+                ids.add(v)
+            elif k == "ID_LIKE":
+                ids.update(v.split())
+
+    if ids & {"debian", "ubuntu"}:
+        argv = ["sudo", "apt-get", "install", "-y", "xvfb"]
+    elif ids & {"fedora", "rhel", "centos"}:
+        argv = ["sudo", "dnf", "install", "-y", "xorg-x11-server-Xvfb"]
+    elif ids & {"arch"}:
+        argv = ["sudo", "pacman", "-S", "--noconfirm", "xorg-server-xvfb"]
+    elif ids & {"alpine"}:
+        argv = ["sudo", "apk", "add", "xvfb"]
+    else:
+        argv = ["sudo", "apt-get", "install", "-y", "xvfb"]
+    return argv, " ".join(argv)
+
+
+def install() -> tuple[bool, str]:
+    """Run the detected install command. Returns (ok, detail)."""
+    argv, human = detect_install_cmd()
+    try:
+        r = subprocess.run(argv, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        return False, f"Package manager not found: {exc}"
+    if r.returncode == 0 and is_installed():
+        return True, "Installed"
+    detail = (r.stderr or r.stdout or "").strip().splitlines()
+    last = detail[-1] if detail else f"exit {r.returncode}"
+    return False, f"{human} failed — {last}"

--- a/garmin_extract/menu.py
+++ b/garmin_extract/menu.py
@@ -164,11 +164,9 @@ def _find_chrome() -> tuple[bool, str | None]:
 
 
 def _find_xvfb() -> bool:
-    try:
-        r = subprocess.run(["which", "Xvfb"], capture_output=True, timeout=5)
-        return r.returncode == 0
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return False
+    from garmin_extract._xvfb import is_installed
+
+    return is_installed()
 
 
 def _missing_packages() -> list[str]:
@@ -350,17 +348,20 @@ def check_prerequisites() -> None:  # noqa: C901
             print("  Xvfb (X Virtual Framebuffer) creates a fake, hidden screen")
             print("  so Chrome has somewhere to render without a real display.")
             print()
+            from garmin_extract._xvfb import detect_install_cmd, install
+
+            _, install_str = detect_install_cmd()
             print("  We can install it now:")
-            print("    sudo apt-get install -y xvfb")
+            print(f"    {install_str}")
             print()
             go = prompt_with_navigation("  Install Xvfb now? [Y/n]: ")
             if go.lower() != "n":
                 print()
-                r = subprocess.run(["sudo", "apt-get", "install", "-y", "xvfb"])
-                if r.returncode == 0 and _find_xvfb():
+                ok, detail = install()
+                if ok:
                     console.print("\n  [green]✓[/]  Xvfb installed.")
                 else:
-                    console.print("\n  [red]✗[/]  Installation may not have completed.")
+                    console.print(f"\n  [red]✗[/]  Installation failed: {detail}")
                     issues.append("Xvfb")
             else:
                 print()

--- a/garmin_extract/screens/data_pull.py
+++ b/garmin_extract/screens/data_pull.py
@@ -13,6 +13,30 @@ from textual.widgets import Footer, Header, Input, Static
 _SECTION = "  [bold dim]{title}[/]\n  " + "─" * 51
 
 
+def _launch_pull(app, **kwargs) -> None:
+    """Push PullProgressScreen, gating on LinuxPreflightScreen when relevant."""
+    import platform
+
+    from garmin_extract.screens.pull_progress import PullProgressScreen
+
+    def _go() -> None:
+        app.push_screen(PullProgressScreen(**kwargs))
+
+    skip_preflight = kwargs.get("rebuild_only") or kwargs.get("zip_path")
+    if skip_preflight or platform.system() != "Linux":
+        _go()
+        return
+
+    from garmin_extract.screens.linux_preflight import LinuxPreflightScreen
+
+    def _after(result: str | None) -> None:
+        if result is None:
+            return
+        _go()
+
+    app.push_screen(LinuxPreflightScreen(), _after)
+
+
 def _date_range_label(days: int) -> str:
     today = date.today()
     start = today - timedelta(days=days)
@@ -182,16 +206,13 @@ class DataPullScreen(Screen[None]):
         no_skip: bool = False,
         rebuild_only: bool = False,
     ) -> None:
-        from garmin_extract.screens.pull_progress import PullProgressScreen
-
-        self.app.push_screen(
-            PullProgressScreen(
-                start_date=start_date,
-                days=days,
-                label=label,
-                no_skip=no_skip,
-                rebuild_only=rebuild_only,
-            )
+        _launch_pull(
+            self.app,
+            start_date=start_date,
+            days=days,
+            label=label,
+            no_skip=no_skip,
+            rebuild_only=rebuild_only,
         )
 
     def action_fetch_new(self) -> None:
@@ -340,11 +361,12 @@ class CustomDateScreen(_InputScreen):
         self._push_pull(start, days)
 
     def _push_pull(self, start: str, days: int) -> None:
-        from garmin_extract.screens.pull_progress import PullProgressScreen
-
         self.app.pop_screen()
-        self.app.push_screen(
-            PullProgressScreen(start_date=start, days=days, label=f"Custom  ({start}, {days}d)")
+        _launch_pull(
+            self.app,
+            start_date=start,
+            days=days,
+            label=f"Custom  ({start}, {days}d)",
         )
 
 
@@ -381,15 +403,12 @@ class FullHistoryScreen(_InputScreen):
             error.update("Start date must be before today.")
             return
 
-        from garmin_extract.screens.pull_progress import PullProgressScreen
-
         self.app.pop_screen()
-        self.app.push_screen(
-            PullProgressScreen(
-                start_date=start,
-                days=days,
-                label=f"Full history  ({start} → {yesterday.isoformat()})",
-            )
+        _launch_pull(
+            self.app,
+            start_date=start,
+            days=days,
+            label=f"Full history  ({start} → {yesterday.isoformat()})",
         )
 
 
@@ -421,14 +440,11 @@ class ImportZipScreen(_InputScreen):
             error.update(f"File not found: {raw}")
             return
 
-        from garmin_extract.screens.pull_progress import PullProgressScreen
-
         self.app.pop_screen()
-        self.app.push_screen(
-            PullProgressScreen(
-                start_date="",
-                days=0,
-                label="Garmin bulk export import",
-                zip_path=raw,
-            )
+        _launch_pull(
+            self.app,
+            start_date="",
+            days=0,
+            label="Garmin bulk export import",
+            zip_path=raw,
         )

--- a/garmin_extract/screens/linux_preflight.py
+++ b/garmin_extract/screens/linux_preflight.py
@@ -1,0 +1,332 @@
+"""Linux preflight — gates pulls on Xvfb, Garmin creds, and Gmail MFA.
+
+On truly-headless Linux (no $DISPLAY) the pull cannot proceed without all
+three: Xvfb installed, Garmin credentials saved, and Gmail MFA configured
+(manual login is impossible with no screen to interact with). On desktop
+Linux the user may still choose manual login as on Windows/macOS.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Static
+
+ROOT = Path(__file__).parent.parent.parent
+GMAIL_CREDS_FILE = ROOT / "google_credentials.json"
+GMAIL_TOKEN_FILE = ROOT / ".google_token.json"
+
+
+def _gmail_configured() -> bool:
+    return GMAIL_CREDS_FILE.exists() and GMAIL_TOKEN_FILE.exists()
+
+
+class LinuxPreflightScreen(ModalScreen[str | None]):
+    """Modal that gates a pull on Linux prerequisites.
+
+    Dismissed values:
+      - "manual"  — user chose manual login (DISPLAY available only)
+      - "auto"    — all required prerequisites satisfied, proceed with auto login
+      - None      — user cancelled
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=True)]
+
+    CSS = """
+    LinuxPreflightScreen {
+        align: center middle;
+    }
+
+    #preflight-box {
+        width: 72;
+        height: auto;
+        max-height: 90%;
+        border: round $accent;
+        padding: 1 2;
+    }
+
+    #preflight-title {
+        text-style: bold;
+        color: $accent;
+        margin-bottom: 1;
+    }
+
+    #preflight-hint {
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    .gate-row {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    .gate-status {
+        height: auto;
+    }
+
+    .gate-actions {
+        height: auto;
+        margin-top: 0;
+    }
+
+    #creds-form {
+        height: auto;
+        display: none;
+        padding: 1 0;
+    }
+
+    #creds-form.visible {
+        display: block;
+    }
+
+    #creds-error {
+        color: $error;
+        height: auto;
+    }
+
+    #preflight-buttons {
+        height: auto;
+        margin-top: 1;
+    }
+
+    Button {
+        margin-right: 1;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._creds_visible = False
+
+    # ── state helpers ────────────────────────────────────────────────────
+
+    def _is_headless(self) -> bool:
+        from garmin_extract._xvfb import is_truly_headless
+
+        return is_truly_headless()
+
+    def _xvfb_needed(self) -> bool:
+        return self._is_headless()
+
+    def _xvfb_ok(self) -> bool:
+        from garmin_extract._xvfb import is_installed
+
+        return is_installed()
+
+    def _creds_ok(self) -> bool:
+        from garmin_extract._credentials import load_credentials
+
+        email, password = load_credentials()
+        return bool(email and password)
+
+    def _mfa_ok(self) -> bool:
+        return _gmail_configured()
+
+    def _can_proceed_auto(self) -> bool:
+        """All required gates must be green."""
+        if self._xvfb_needed() and not self._xvfb_ok():
+            return False
+        if self._is_headless():
+            return self._creds_ok() and self._mfa_ok()
+        return self._creds_ok()
+
+    # ── compose ──────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="preflight-box"):
+            yield Static("Linux Preflight", id="preflight-title")
+            yield Static("", id="preflight-hint")
+
+            # Xvfb row (only meaningful when headless)
+            with Vertical(classes="gate-row", id="xvfb-row"):
+                yield Static("", id="xvfb-status", classes="gate-status")
+                with Horizontal(classes="gate-actions", id="xvfb-actions"):
+                    yield Button("Install Xvfb", id="install-xvfb", variant="primary")
+
+            # Credentials row
+            with Vertical(classes="gate-row", id="creds-row"):
+                yield Static("", id="creds-status", classes="gate-status")
+                with Horizontal(classes="gate-actions", id="creds-actions"):
+                    yield Button("Configure auto login", id="configure-creds")
+                with Vertical(id="creds-form"):
+                    yield Input(placeholder="Garmin email", id="creds-email")
+                    yield Input(
+                        placeholder="Garmin password",
+                        id="creds-password",
+                        password=True,
+                    )
+                    yield Static("", id="creds-error")
+                    with Horizontal():
+                        yield Button("Save", id="save-creds", variant="primary")
+                        yield Button("Cancel", id="cancel-creds")
+
+            # Gmail MFA row
+            with Vertical(classes="gate-row", id="mfa-row"):
+                yield Static("", id="mfa-status", classes="gate-status")
+                with Horizontal(classes="gate-actions", id="mfa-actions"):
+                    yield Button("Configure Gmail MFA", id="configure-mfa")
+
+            # Action row
+            with Horizontal(id="preflight-buttons"):
+                yield Button("Log in manually", id="manual", variant="success")
+                yield Button("Continue", id="continue", variant="primary")
+                yield Button("Cancel", id="cancel")
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        self._refresh()
+
+    def on_screen_resume(self) -> None:
+        # Re-run when returning from the pushed GmailSetupScreen
+        self._refresh()
+
+    def _refresh(self) -> None:
+        headless = self._is_headless()
+
+        hint = (
+            "Headless Linux — automation requires Xvfb, saved Garmin credentials, "
+            "and Gmail MFA. Manual login is unavailable without a display."
+            if headless
+            else "Choose how to log in. Auto login saves your credentials to the OS "
+            "keyring for future unattended runs."
+        )
+        self.query_one("#preflight-hint", Static).update(hint)
+
+        # ── Xvfb
+        xvfb_row = self.query_one("#xvfb-row", Vertical)
+        if self._xvfb_needed():
+            xvfb_row.display = True
+            ok = self._xvfb_ok()
+            self.query_one("#xvfb-status", Static).update(
+                "[green]✓[/]  Xvfb installed"
+                if ok
+                else "[red]✗[/]  Xvfb not installed — required for headless Chrome"
+            )
+            self.query_one("#install-xvfb", Button).display = not ok
+        else:
+            xvfb_row.display = False
+
+        # ── Credentials
+        creds_ok = self._creds_ok()
+        creds_required = headless
+        creds_label = (
+            "[green]✓[/]  Garmin credentials saved"
+            if creds_ok
+            else (
+                "[red]✗[/]  Garmin credentials not configured — required for headless"
+                if creds_required
+                else "[yellow]○[/]  Garmin credentials not configured (optional)"
+            )
+        )
+        self.query_one("#creds-status", Static).update(creds_label)
+        self.query_one("#configure-creds", Button).display = not self._creds_visible
+
+        # ── Gmail MFA
+        mfa_row = self.query_one("#mfa-row", Vertical)
+        if headless:
+            mfa_row.display = True
+            mfa_ok = self._mfa_ok()
+            self.query_one("#mfa-status", Static).update(
+                "[green]✓[/]  Gmail MFA configured"
+                if mfa_ok
+                else "[red]✗[/]  Gmail MFA not configured — required for headless"
+            )
+        else:
+            mfa_row.display = False
+
+        # ── Buttons
+        self.query_one("#manual", Button).display = not headless
+        self.query_one("#continue", Button).disabled = not self._can_proceed_auto()
+
+    # ── events ───────────────────────────────────────────────────────────
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        bid = event.button.id
+        if bid == "cancel":
+            self.dismiss(None)
+        elif bid == "manual":
+            self.dismiss("manual")
+        elif bid == "continue":
+            if self._can_proceed_auto():
+                self.dismiss("auto")
+        elif bid == "install-xvfb":
+            self._install_xvfb()
+        elif bid == "configure-creds":
+            self._show_creds_form()
+        elif bid == "cancel-creds":
+            self._hide_creds_form()
+        elif bid == "save-creds":
+            self._save_creds()
+        elif bid == "configure-mfa":
+            self._open_mfa_setup()
+
+    def _install_xvfb(self) -> None:
+        btn = self.query_one("#install-xvfb", Button)
+        btn.disabled = True
+        btn.label = "Installing…"
+        self.run_worker(self._xvfb_worker, thread=True, exclusive=True)
+
+    def _xvfb_worker(self) -> None:
+        from garmin_extract._xvfb import install
+
+        ok, detail = install()
+        self.app.call_from_thread(self._xvfb_done, ok, detail)
+
+    def _xvfb_done(self, ok: bool, detail: str) -> None:
+        btn = self.query_one("#install-xvfb", Button)
+        btn.disabled = False
+        btn.label = "Install Xvfb"
+        if not ok:
+            self.notify(detail, severity="error", title="Xvfb install failed")
+        self._refresh()
+
+    def _show_creds_form(self) -> None:
+        self._creds_visible = True
+        self.query_one("#creds-form").add_class("visible")
+        self.query_one("#configure-creds", Button).display = False
+        from garmin_extract._credentials import load_credentials
+
+        email, _ = load_credentials()
+        if email:
+            self.query_one("#creds-email", Input).value = email
+        self.query_one("#creds-email", Input).focus()
+
+    def _hide_creds_form(self) -> None:
+        self._creds_visible = False
+        self.query_one("#creds-form").remove_class("visible")
+        self.query_one("#creds-error", Static).update("")
+        self._refresh()
+
+    def _save_creds(self) -> None:
+        email = self.query_one("#creds-email", Input).value.strip()
+        password = self.query_one("#creds-password", Input).value.strip()
+        err = self.query_one("#creds-error", Static)
+        if not email or not password:
+            err.update("Email and password are required.")
+            return
+        from garmin_extract._credentials import detect_keyring, save_to_env, save_to_keyring
+
+        keyring_ok, _ = detect_keyring()
+        if keyring_ok:
+            ok, detail = save_to_keyring(email, password)
+            if not ok:
+                err.update(f"Keyring save failed: {detail}")
+                return
+        else:
+            save_to_env(email, password)
+        err.update("")
+        self._hide_creds_form()
+
+    def _open_mfa_setup(self) -> None:
+        from garmin_extract.screens.setup import GmailSetupScreen
+
+        self.app.push_screen(GmailSetupScreen())
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/garmin_extract/screens/setup.py
+++ b/garmin_extract/screens/setup.py
@@ -41,9 +41,9 @@ def _check_xvfb() -> tuple[bool, str]:
 
     if os.environ.get("DISPLAY"):
         return True, "Not needed — display available"
-    from garmin_extract.menu import _find_xvfb
+    from garmin_extract._xvfb import is_installed
 
-    found = _find_xvfb()
+    found = is_installed()
     return found, "Installed" if found else "Not found"
 
 
@@ -550,9 +550,12 @@ class _InstallScreen(Screen[None]):
                 proc.wait()
 
         if self._states.get("Xvfb") == "fail":
+            from garmin_extract._xvfb import detect_install_cmd
+
+            argv, _ = detect_install_cmd()
             self.app.call_from_thread(log.write, "\n[bold]Installing Xvfb…[/bold]")
             proc = subprocess.Popen(
-                ["sudo", "apt-get", "install", "-y", "xvfb"],
+                argv,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -67,6 +68,18 @@ from garmin_extract._browser import detect_windows_browser  # noqa: E402
 
 
 def start_xvfb(display=":99"):
+    if shutil.which("Xvfb") is None:
+        from garmin_extract._xvfb import detect_install_cmd
+
+        _, install_str = detect_install_cmd()
+        print("ERROR: Xvfb is required on headless Linux but is not installed.")
+        print(f"  Install it with:  {install_str}")
+        print("  Then re-run this command.")
+        print(
+            "  (Or run the TUI —  uv run python -m garmin_extract  — "
+            "which can install Xvfb for you.)"
+        )
+        sys.exit(1)
     proc = subprocess.Popen(
         ["Xvfb", display, "-screen", "0", "1280x720x24"],
         stdout=subprocess.DEVNULL,

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -153,11 +153,6 @@ def ensure_logged_in(sb, email: str = "", password: str = "") -> None:
     If email/password are provided, login is automated. Otherwise the browser
     opens to the login page and waits for the user to log in manually.
     """
-    # Remove stale Chrome lock files that prevent profile reuse
-    lock = PROFILE_DIR / "SingletonLock"
-    if lock.exists():
-        lock.unlink()
-
     sb.uc_open_with_reconnect("https://connect.garmin.com/modern/", reconnect_time=3)
     sb.sleep(3)
 
@@ -725,9 +720,19 @@ def main():
     try:
         print("Launching browser...")
         PROFILE_DIR.mkdir(exist_ok=True)
+        # Clear any stale Chrome singleton files from a prior crashed run. Chrome treats
+        # leftover SingletonSocket/SingletonCookie as "another instance is already using
+        # this profile" and exits before ChromeDriver can connect.
+        for stale in PROFILE_DIR.glob("Singleton*"):
+            stale.unlink(missing_ok=True)
         # headless=False required — UC mode's uc_open_with_reconnect closes and reopens the
         # Chrome window as part of its Cloudflare bypass; headless mode breaks that mechanism.
         sb_kwargs = dict(uc=True, headless=False, xvfb=False, user_data_dir=str(PROFILE_DIR))
+        if platform.system() == "Linux":
+            # KVM/container guests commonly lack unprivileged user-namespaces, so Chrome's
+            # sandbox can't initialize; /dev/shm is also frequently undersized. Comma-separated
+            # because SeleniumBase splits chromium_arg on "," (not whitespace).
+            sb_kwargs["chromium_arg"] = "--no-sandbox,--disable-dev-shm-usage"
         if browser_bin:
             sb_kwargs["binary_location"] = browser_bin
         with SB(**sb_kwargs) as sb:

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.4.3"
+version = "1.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

- Adds a Textual preflight modal that gates pulls on Linux prerequisites (Xvfb installed, Garmin credentials saved, Gmail MFA configured), mirroring the Windows progressive-disclosure login dialog (#63).
- Truly-headless Linux (no `$DISPLAY`) hides the manual-login button and disables **Continue** until every required gate is green; desktop Linux keeps manual login as an option like Windows/macOS.
- Hardens `pullers/garmin.py::start_xvfb()` so a missing Xvfb binary prints a distro-aware install command and exits cleanly instead of crashing the cron path.
- Extracts shared Xvfb detection/install logic into `garmin_extract/_xvfb.py` (apt / dnf / pacman / apk) and refactors the print menu + TUI setup screen to use it.

Closes #80

## Test plan

- [x] `ruff check .` + `black --check .` clean
- [x] TUI smoke test: Main → Pull Data → Yesterday pushes `LinuxPreflightScreen`; Escape returns to Data Pull menu
- [x] Preflight gate logic: **Continue** disabled and manual button hidden when box reports truly-headless with no creds / no MFA
- [x] Progressive disclosure: "Configure auto login" reveals creds form; Save persists via `_credentials.save_to_keyring` fallback to `.env`
- [x] Simulated missing-Xvfb call to `start_xvfb()` exits 1 with actionable install command
- [ ] End-to-end on headless Linux VM: install flow, creds save, Gmail OAuth round-trip, auto-pull completes
- [ ] Desktop Linux with `$DISPLAY`: manual-login button visible, auto-login path unchanged
- [ ] Non-Linux (Windows/macOS) regression: preflight is skipped, existing flows unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)