### PR TITLE
fix(gmail): match current Garmin MFA sender + "Passcode" subject (#83)

### DIFF
--- a/pullers/_gmail_mfa.py
+++ b/pullers/_gmail_mfa.py
@@ -134,18 +134,22 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
         elapsed += poll_interval
 
         try:
-            # Search for Garmin MFA emails received since script start
+            # Search for Garmin MFA emails received since script start.
+            # Garmin currently sends from alerts@account.garmin.com with subject
+            # "Your Security Passcode"; older runs used noreply@garmin.com.
+            # Gmail tokenizes on word boundaries, so "passcode" must be listed
+            # explicitly — "code" does not match "Passcode".
             query = (
-                f"from:noreply@garmin.com "
+                f"from:(noreply@garmin.com OR alerts@account.garmin.com) "
                 f"after:{start_epoch_s} "
-                f"subject:(security code OR verification OR sign-in)"
+                f"subject:(security code OR passcode OR verification OR sign-in)"
             )
             result = service.users().messages().list(userId="me", q=query, maxResults=5).execute()
 
             messages = result.get("messages", [])
             if not messages:
-                # Broader fallback — any recent garmin.com email
-                query2 = f"from:garmin.com after:{start_epoch_s}"
+                # Broader fallback — any recent email from a garmin.com domain.
+                query2 = f"from:(garmin.com OR account.garmin.com) after:{start_epoch_s}"
                 result2 = (
                     service.users().messages().list(userId="me", q=query2, maxResults=5).execute()
                 )


### PR DESCRIPTION
## Summary

- Widens `pullers/_gmail_mfa.py::wait_for_mfa_gmail()` to match Garmin's current MFA emails: sender `alerts@account.garmin.com`, subject `Your Security Passcode`.
- Primary `from:` now lists both known senders explicitly (`noreply@garmin.com` OR `alerts@account.garmin.com`).
- Primary `subject:` adds `passcode` as its own token — Gmail tokenizes on word boundaries, so `code` does not match `Passcode`.
- Fallback `from:` includes `account.garmin.com` explicitly rather than relying on undocumented subdomain tokenization.

Closes #83

## Test plan

- [x] `ruff check .` + `black --check .` clean
- [ ] End-to-end: headless Linux pull hits Garmin MFA → Gmail polling finds the \"Your Security Passcode\" email from `alerts@account.garmin.com` within the 300s window
- [ ] Regression: if an older account still receives from `noreply@garmin.com`, polling still matches
- [ ] No auth/token changes — existing `.google_token.json` scopes continue to work

## Not in scope

- MFA timeout (300s) unchanged — the 19-second-outside-window miss seen during the #80 test run was an artifact of repeated logins stacking Garmin's delivery queue, not the normal case
- Token refresh behavior
- Any Linux-specific changes (already shipped in #82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)