### PR TITLE
chore: release v1.6.1 — headless Linux fixes, Gmail query robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,446 +6,148 @@ Pull 30+ daily health metrics from Garmin Connect automatically — including on
 
 Garmin has no public API for personal health data. Every Python library that tries to authenticate directly (`garminconnect`, `garth`, raw `requests`) gets blocked by Cloudflare's bot protection before the login page even loads.
 
-This project solves the problem by running a **real Chrome browser** (via SeleniumBase's undetected-chromedriver mode). All API calls are executed as JavaScript `fetch()` calls from inside the browser context — Python only orchestrates what the browser does. Cloudflare sees a legitimate browser with a real TLS fingerprint and lets it through. On headless Linux servers, Chrome runs inside a virtual framebuffer (Xvfb); on desktop systems it runs directly.
+This project solves the problem by running a **real Chrome browser** (via SeleniumBase's undetected-chromedriver mode). All API calls are executed as JavaScript `fetch()` calls from inside the browser context — Python only orchestrates what the browser does. Cloudflare sees a legitimate browser with a real TLS fingerprint and lets it through.
 
-Once logged in, Chrome saves the session to a local browser profile and reuses it on subsequent runs. Re-authentication is only needed about once every 30 days.
+Once logged in, the browser saves the session to a local profile and reuses it on subsequent runs. Re-authentication is only needed about once every 30 days.
 
 ## Features
 
-- **Interactive TUI** — a full terminal interface that walks you through setup, data pulls, and automation without touching the command line; navigate with arrow keys, `j/k`, number shortcuts, or `enter`
 - **30+ metrics per day** — steps, heart rate, sleep, HRV, stress, body battery, SpO2, respiration, training readiness, nutrition, activities, and more
-- **Per-activity detail** — 8 additional endpoints per workout (splits, HR zones, power zones, exercise sets, weather, and more)
-- **One-time profile pull** — devices, personal records, training plans, and gear saved to `profile.json`
-- **Fetch New** — automatically detects the most recent local date and pulls only the gap to yesterday; no manual date math required
-- **Historical backfill** from Garmin's bulk data export (`.zip` file)
+- **Per-activity detail** — splits, HR zones, power zones, exercise sets, weather
+- **One-time profile pull** — devices, personal records, training plans, gear
+- **Fetch New** — automatically pulls only the gap between your latest local data and yesterday
+- **Historical backfill** from Garmin's bulk data export (`.zip`)
 - **CSV export** — `garmin_daily.csv` (daily metrics) and `garmin_activities.csv` (per-workout)
-- **Google Drive / Sheets export** — upload CSVs to Drive or sync to a live Google Sheet, all from inside the TUI
-- **Secure credential storage** — passwords saved to OS keyring (SecretService / Credential Manager / Keychain) by default; `.env` fallback with plaintext warning if keyring is unavailable; runtime-only entry if no storage is desired
+- **Google Drive / Sheets export** — archive raw CSVs to a Drive folder *and / or* populate a live Google Sheet for dashboards and sharing
+- **Automatic MFA via Gmail** — reads your Garmin security code from Gmail so session renewals need no human action
+- **Scheduled Pulls** — daily unattended pulls via Windows Task Scheduler (GUI) or `cron` on Linux
+- **Secure credential storage** — passwords saved to OS keyring by default (Credential Manager on Windows, Keychain on macOS, SecretService on Linux)
 - Partial failures are non-fatal — the daily file is written with whatever succeeded
 - Idempotent — safe to run multiple times; already-pulled dates are skipped by default
 
-**Optional automation:**
-- Fully automatic MFA via Gmail API — the tool reads your Garmin security code from Gmail so session renewals require no human action
-- **Scheduled Pulls on Windows** via Task Scheduler — pick a time in the GUI, optionally bundle Drive / Sheets export, fully unattended thereafter
-- **Scheduled Pulls on Linux** via `cron` using `scripts/pull-garmin.sh`
-- **Google Drive / Sheets export** triggered on demand or as part of a scheduled pull — archive raw CSVs to a Drive folder of your choice *and / or* populate a live Google Sheet for dashboards and sharing
+## Install
 
-## Requirements
+### Windows
 
-- **Windows, macOS, or Linux** (headless or desktop) — tested on Ubuntu 24.04
-- Google Chrome installed
-- `xvfb` on headless Linux only (not needed on Windows, macOS, or Linux with a display)
-- Python 3.12+
-- A Garmin account with email MFA enabled (standard on all accounts)
-- A Gmail account for MFA automation (optional but strongly recommended for unattended operation)
+1. Download the latest `garmin-extract-windows-vX.Y.Z.zip` from the [Releases page](https://github.com/ColonelPanicX/garmin-extract/releases)
+2. Extract the zip to a folder of your choice (e.g. `C:\Program Files\garmin-extract`)
+3. Double-click `garmin-extract.exe`
 
-## Quickstart
+That's it. Chrome, Brave, or Edge is required — the app detects whichever is installed (preferring Chrome, then Brave, then Edge).
 
-### 1. Install Chrome
+> **Chrome hangs on startup?** Known issue tracked in [#74](https://github.com/ColonelPanicX/garmin-extract/issues/74). Brave and Edge work cleanly as a workaround.
 
-**Linux:**
+### macOS
+
+*Coming later.* macOS builds are not yet published.
+
+### Headless Linux
+
+Headless Linux requires a one-time setup of prerequisites, then running from source. A packaged Linux build is not yet available.
+
 ```bash
+# Install Chrome
 wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" \
     | sudo tee /etc/apt/sources.list.d/google-chrome.list
 sudo apt update && sudo apt install -y google-chrome-stable
-```
 
-**Headless Linux only** — also install Xvfb:
-```bash
+# Install Xvfb (virtual display — required for headless Chrome)
 sudo apt install -y xvfb
-```
 
-**Windows / macOS:** Download from [google.com/chrome](https://www.google.com/chrome/).
-
-### 2. Clone and install
-
-```bash
+# Install garmin-extract
 git clone https://github.com/ColonelPanicX/garmin-extract.git
 cd garmin-extract
-```
-
-**With [uv](https://docs.astral.sh/uv/) (recommended):**
-```bash
 uv sync
 uv run python -m garmin_extract
 ```
 
-**With pip:**
-```bash
-python3 -m venv .venv
-source .venv/bin/activate        # Windows: .venv\Scripts\activate
-pip install -e .
-python -m garmin_extract
-```
+The app auto-starts Xvfb when needed, but the `xvfb` binary must be installed first.
 
-### 3. Follow the TUI
+## First-time setup
 
-The interactive TUI is the recommended way to get started. On launch you'll land on the main menu:
+The app walks you through setup on first launch. Expected order:
 
-```
-  garmin-extract  v1.3.0
-  Automated Garmin Connect data pipeline
+1. **Garmin Credentials** *(optional)* — enter your Garmin email and password. Saved to the OS keyring (encrypted at rest). Skip this if you'd rather log in manually each time.
+2. **Gmail MFA** *(optional but strongly recommended)* — Automation → Gmail MFA → Configure. A 3-step wizard walks you through obtaining an OAuth credentials file from Google Cloud Console, authorizing the app, and saving a long-lived token. Once configured, Garmin's email MFA prompts are handled automatically — pulls run fully unattended.
+3. **First pull** — Pull Data → Fetch new. On the first pull, the browser opens, you log in (or the app does it for you if you saved credentials), MFA is handled, and a session is saved to `.garmin_browser_profile/`. Subsequent runs reuse that session for ~30 days.
 
-  ┌─────────────────────────────────────────────────────┐
-  │   [1]  Initial Setup                                │
-  │   [2]  Pull Data                                    │
-  │   [3]  Automation                                   │
-  └─────────────────────────────────────────────────────┘
-```
+## Daily use
 
-All menus support keyboard navigation: `↑↓` or `j/k` to move, `enter` to select, number keys for direct access.
+Launch the app and go to **Pull Data**:
 
-**First-time setup order:**
+- **Fetch new** — pulls every date between your most recent local data and yesterday
+- **Yesterday** — just yesterday's data
+- **Last 7 days** / **Last 30 days** — common ranges
+- **Specific date or range** — enter a start date (and optionally a day count)
+- **Full history** — every date between a start date you choose and yesterday
+- **Import from Garmin bulk export** — ingest the `.zip` that Garmin emails you if you request your data export
+- **Rebuild CSV reports** — regenerate `garmin_daily.csv` and `garmin_activities.csv` from existing local JSON
 
-1. **Initial Setup → Prerequisites** — verifies Chrome, Xvfb (Linux), Python version, and packages. Installs missing prerequisites on Linux.
-2. **Initial Setup → Garmin Credentials** — enter your Garmin email and password. Saved to the OS keyring by default (encrypted at rest). If keyring is unavailable, you'll be offered `.env` storage with a plaintext warning, or you can skip saving and enter credentials at runtime before each pull.
-3. **Initial Setup → Gmail OAuth** *(optional but recommended)* — authorizes the Gmail API so MFA codes are fetched automatically. The same OAuth token also grants access to Google Drive and Sheets. See [Gmail MFA automation](#gmail-mfa-automation).
-4. **Pull Data** — choose a date range and pull. On the first pull, Chrome launches, logs in, handles MFA, and saves a session to `.garmin_browser_profile/`. Subsequent runs reuse that session.
+The **Latest Sync** header at the top of the Pull Data screen shows how many days behind you are at a glance.
 
-### 4. Schedule automatic pulls *(optional)*
+## Automation
 
-From the main menu, go to **Automation → Scheduled Pulls**. Press `i` to enable a daily pull at 6:00 AM (default), or `e` to choose a different hour. Output is logged to `/tmp/garmin-pull.log`.
+### Gmail MFA
 
-Alternatively, add the shell wrapper directly to your crontab:
-```
+Automation → Gmail MFA → Configure opens a 3-step wizard. Once configured, the app polls Gmail for the MFA code when Garmin asks for one — no manual input required. The same OAuth token grants access to Google Drive and Sheets.
+
+### Scheduled Pulls (Windows)
+
+Automation → Scheduled Pulls → Configure:
+
+- Pick a daily time
+- Optionally tick **Archive raw CSV files to Google Drive** and / or **Populate Google Sheet with data**
+- Save
+
+The app creates a Windows Task Scheduler entry that runs `garmin-extract --pull` at the chosen time. Verify it in Task Scheduler under the name `garmin-extract-daily`.
+
+### Scheduled Pulls (Linux)
+
+Add the shell wrapper to your crontab:
+
+```cron
 0 6 * * * /path/to/garmin-extract/scripts/pull-garmin.sh
 ```
 
-### 5. Export to Google Drive / Sheets *(optional)*
+The script supports `--push-drive` / `--push-sheets` / `--push-both` flags to bundle exports with the pull.
 
-From the main menu, go to **Automation → Google Drive / Sheets**. Three options — pick the one that matches how you'll actually use the data:
+### Google Drive / Sheets export
 
-- **[1] Upload CSVs to Drive** — *archival*. Uploads `garmin_daily.csv` and `garmin_activities.csv` as raw files into the Drive folder you choose (defaults to `Garmin Extract`). Each run overwrites the files in place. Best for backups, version history, or feeding the CSVs into another tool. Clicking a CSV in Drive opens a read-only Sheets preview; converting it to an editable Sheet produces a one-off copy that won't update on future pulls.
-
-- **[2] Sync to Google Sheets** — *live dashboard*. Writes the data into a persistent `Garmin Data` spreadsheet with `Daily` and `Activities` tabs. The Sheet's URL stays stable run after run — only the cells change. Best for bookmarking a single URL to come back to, building charts / pivots / dashboards on top of the data, or sharing a live view with someone. Charts and formatting you add to the Sheet stay attached and keep updating.
-
-- **[3] Both** — runs Drive upload and Sheets sync in sequence. Fine if you want both the raw-file archive *and* the live Sheet.
-
-The folder ID and sheet ID are saved locally in `.drive_config.json` so subsequent exports update the same resources. Requires Gmail OAuth to be configured first — the same token covers Drive and Sheets access.
-
-**Choosing between them:**
+Automation → Google Drive / Sheets. Two complementary exports — pick the one that matches your use case:
 
 | Use case | Pick |
 |---|---|
-| "Give me backups I can download later." | Upload CSVs to Drive |
-| "Bookmark one Sheet I can open to see today's data." | Sync to Sheets |
-| "Share a live view with my spouse / coach / doctor." | Sync to Sheets |
-| "Build pivot tables or charts that auto-update." | Sync to Sheets |
-| "Export to another tool that reads CSV." | Upload CSVs to Drive |
-| "Both, for belt-and-suspenders." | Both |
+| Backups you can download later | **Upload CSVs to Drive** (archival) |
+| Bookmark one Sheet to see today's data | **Sync to Sheets** (live dashboard) |
+| Share a live view with someone | **Sync to Sheets** |
+| Build pivot tables / charts that auto-update | **Sync to Sheets** |
+| Export to another tool that reads CSV | **Upload CSVs to Drive** |
+| Both, for belt-and-suspenders | **Both** |
 
-## Usage
+- **Upload CSVs to Drive** — uploads `garmin_daily.csv` and `garmin_activities.csv` as raw files into a folder you choose. Each run overwrites the files in place. Clicking a CSV in Drive opens a read-only Sheets preview; converting it to an editable Sheet produces a one-off copy that won't update on future pulls.
+- **Sync to Sheets** — writes the data into a persistent `Garmin Data` spreadsheet with `Daily` and `Activities` tabs. The URL stays stable run after run — only the cells change. Charts and formatting you add keep updating.
 
-### TUI
-
-```bash
-uv run python -m garmin_extract      # recommended
-python garmin_extract.py             # alternate shim
-```
-
-### CLI (scripting / headless)
-
-```bash
-uv run python -m garmin_extract --no-tui   # print menu, no TUI
-```
-
-### Daily puller (direct)
-
-```bash
-python pullers/garmin.py                               # yesterday (default)
-python pullers/garmin.py --date 2026-03-01             # specific date
-python pullers/garmin.py --date 2026-03-01 --days 30   # 30-day range
-python pullers/garmin.py --no-skip                     # re-pull existing dates
-```
-
-### Historical backfill
-
-Request your data export from **Garmin Connect → Profile → Account → Your Garmin Data**. The export arrives within 24–48 hours as a `.zip` file.
-
-```bash
-python pullers/garmin_import_export.py path/to/export.zip
-python pullers/garmin_import_export.py path/to/export.zip --no-skip
-```
-
-Reads six data categories from the zip and writes one JSON file per day. Skips dates that already have a live-pulled file (which contain richer data).
-
-### CSV export
-
-```bash
-python reports/build_garmin_csvs.py
-python reports/build_garmin_csvs.py --since 2025-01-01
-```
-
-Outputs:
-- `reports/garmin_daily.csv` — one row per day (steps, HR, sleep, stress, HRV, body battery, SpO2, training load, nutrition, lifestyle logging, and more)
-- `reports/garmin_activities.csv` — one row per workout (name, type, duration, distance, HR, power, etc.)
-
-## Gmail MFA automation
-
-When Garmin requires an MFA code (approximately every 30 days), this module polls your Gmail inbox automatically, finds the security code email, and submits the code to the browser — no human required.
-
-### Setup via TUI
-
-Go to **Initial Setup → Gmail OAuth** and follow the on-screen steps:
-
-1. Place your `google_credentials.json` (downloaded from Google Cloud Console) in the project root
-2. Select **Authorize Gmail** — an authorization URL is displayed inside the dialog
-3. Open the URL in any browser (does not need to be on the same machine), authorize, and paste the code back
-4. Done — a token is saved to `.google_token.json` and does not expire unless revoked
-
-**To create credentials:** Go to [console.cloud.google.com](https://console.cloud.google.com) → New project → Enable Gmail API → Credentials → OAuth 2.0 Client ID → Desktop app → Download JSON.
-
-### Setup via CLI
-
-```bash
-python scripts/setup_gmail_auth.py
-```
-
-### Fallback
-
-If Gmail automation is not configured (or fails), the TUI shows an MFA dialog prompting you to enter the code manually. At the CLI, the pipeline prints:
-
-```
-MFA REQUIRED — check your email
-Run: echo YOUR_CODE > /path/to/.mfa_code
-Waiting up to 5 minutes...
-```
-
-### Verify status
-
-Go to **Automation → Gmail MFA** to see whether the automation is active, partial, or unconfigured — and what to do if something is wrong.
-
-## Data output
-
-### JSON format
-
-Each pull writes `data/garmin/YYYY-MM-DD.json` containing all metrics as top-level keys, plus a `_meta` block:
-
-```json
-{
-  "stats":              { ... },
-  "sleep":              { ... },
-  "heart_rates":        { ... },
-  "hrv":                "EMPTY",
-  "activities":         [ ... ],
-  "_meta": {
-    "date":         "2026-04-07",
-    "pulled_at":    "2026-04-08T06:01:23Z",
-    "source":       "garmin-browser",
-    "display_name": "<garmin-user-uuid>",
-    "uuid":         ""
-  }
-}
-```
-
-Failed metrics are recorded inline rather than aborting the pull:
-```json
-{ "training_readiness": { "ok": false, "status": 404, "data": null } }
-```
-
-### Metrics pulled (per date)
-
-| Key | Description |
-|---|---|
-| `stats` | 91-field daily summary: steps, calories, active time, HR zones, stress summary, SpO2 |
-| `heart_rates` | Full 24h heart rate timeline with min/max/resting |
-| `sleep` | Sleep stages (deep/light/REM/awake seconds), scores, SpO2, respiration, HR |
-| `hrv` | Overnight HRV weekly average and last-night value |
-| `stress` | Full stress timeline and body battery values |
-| `body_battery` | Daily body battery start/end/high/low stats |
-| `activities` | Logged workout activities |
-| `spo2` | Blood oxygen: daily average, daily low, sleep average |
-| `respiration` | Respiration rate: waking average, sleep average, intraday timeline |
-| `training_readiness` | Training readiness score and contributing factors |
-| `training_status` | Training load balance, VO2Max trend, status label |
-| `fitness_age` | Calculated fitness age vs. chronological age |
-| `hydration` | Daily hydration intake vs. goal |
-| `nutrition_food_log` | Food log entries for the day |
-| `nutrition_meals` | Meal-level nutrition summary |
-| `menstrual_cycle` | Menstrual cycle tracking data |
-| `lifestyle` | Lifestyle behavior logging (alcohol, caffeine, sleep aids, etc.) |
-| ...and more | Steps, floors, intensity minutes, resting HR, body composition, blood pressure, etc. |
-
-**Per-activity detail** (pulled for each logged workout): splits, typed splits, split summaries, HR time in zones, power time in zones, exercise sets, weather.
-
-**One-time profile pull** (per session): devices, user profile, personal records, training plans, workouts, gear → `data/garmin/profile.json`.
+Configure once, run on demand from the Automation page, or bundle with Scheduled Pulls for fully unattended export.
 
 ## Troubleshooting
 
-**Pull fails immediately or browser crashes (exit code 1, no metrics pulled)**
+- **Chrome hangs on startup with "failed to close window in 20 seconds"** — known issue ([#74](https://github.com/ColonelPanicX/garmin-extract/issues/74)). Workaround: use Brave or Edge. The app's browser detection order is Chrome → Brave → Edge; installing Brave alongside Chrome doesn't fix it (Chrome wins detection), but uninstalling Chrome falls through to Brave.
+- **Login keeps failing after a long time** — your Garmin session has expired (happens roughly every 30 days). The app will re-authenticate automatically if credentials and Gmail MFA are configured. If not, the browser will open for manual login.
+- **Gmail MFA doesn't fire** — make sure the OAuth token actually has the `gmail.readonly` scope. Re-run the Gmail MFA wizard if in doubt. The Automation page shows the current Gmail MFA status on mount.
+- **Metrics start coming back empty or 404** — Garmin's internal API endpoints are reverse-engineered from the Connect web app and occasionally change with app updates. If this happens, the endpoints will need to be re-mapped using Chrome DevTools → Network tab while browsing Garmin Connect.
 
-The saved Chrome session in `.garmin_browser_profile/` may be stale or corrupted. Clear it to force a fresh login:
-
-```bash
-rm -rf .garmin_browser_profile/
-```
-
-Then re-run. Chrome will log in fresh, trigger MFA, and save a new session. This is the most common fix after long gaps between pulls or after Garmin rotates session tokens (~30 days).
-
----
-
-**MFA modal never appears / pull hangs waiting for a code**
-
-Make sure Gmail automation is fully configured (Setup → Gmail MFA). If only Drive/Sheets OAuth was completed, the Gmail scope is missing and the puller will skip Gmail polling and show the manual MFA modal instead.
-
----
-
-**Metrics return empty or 404**
-
-Garmin's API endpoints are reverse-engineered from the Connect SPA and may change with app updates. If data stops coming back, the endpoints likely need to be re-mapped using Chrome DevTools → Network tab while browsing Garmin Connect.
-
----
+More detail in the [Troubleshooting wiki page](https://github.com/ColonelPanicX/garmin-extract/wiki/Troubleshooting).
 
 ## Known limitations
 
-- Tested on **Ubuntu 24.04**. Windows and macOS are supported but less tested.
+- **Tested primarily on Windows and Ubuntu 24.04.** macOS is not yet officially supported.
 - Requires a Garmin account with **email MFA enabled** (this is standard on all accounts).
-- The API endpoints are **reverse-engineered from the Garmin Connect SPA**. They may change with Garmin app updates. If metrics start returning 404/empty responses, the endpoints may need to be re-mapped using Chrome DevTools → Network tab.
+- The API endpoints are **reverse-engineered from the Garmin Connect SPA** and may change with Garmin app updates.
 
 ## Changelog
 
-### v1.6.0 — 2026-04-20 — Windows GUI polish, Scheduled Pulls, export UX
-
-A session of iterative UAT on Windows turned into a big step forward for the GUI. The headline additions are **Scheduled Pulls** on Windows (no more editing `.env` and opening Task Scheduler by hand), a much clearer **Drive / Sheets export** story, and a pile of small-but-important UX fixes.
-
-**Scheduled Pulls (Windows)** — Automation → Scheduled Pulls → Configure:
-- Time picker plus optional Drive / Sheets export on the same dialog
-- Backed by Windows Task Scheduler via the `schtasks` CLI. `schtasks /create` on Save, `schtasks /delete` on Disable, `schtasks /query` to show current state
-- New `--pull` flag on the `garmin-extract` CLI mirrors `scripts/pull-garmin.sh`: pulls yesterday, rebuilds CSVs, optionally runs `--push-drive` / `--push-sheets`. Non-interactive, exits 0/1 — safe for cron and Task Scheduler alike
-- Auto-detects frozen vs source mode so the scheduled command resolves to either `garmin-extract.exe --pull` or `.venv\Scripts\python.exe -m garmin_extract --pull`
-- Dialog pre-fills time and export flags from the installed task when reopened
-
-**Login UX overhaul** (Pull Data → Fetch new with no saved creds):
-- Dialog now defaults to **manual** browser login — the form for saving credentials is hidden behind a secondary "Configure auto login" button (progressive disclosure). First-time users aren't pushed into credential configuration they may not want
-- Cancel on this dialog now actually cancels. Previously the cred check ran inside `__init__` before `exec()` had started the parent dialog's event loop, so `self.reject()` had no event loop to end and the pull would proceed anyway. Fixed with `QTimer.singleShot(0, ...)`
-
-**Latest Sync header** (Pull Data screen):
-- New section at the top showing the most recent local data date and days-behind
-- Green `(up to date)` when latest ≥ yesterday, amber `(N days out of sync)` otherwise
-- Empty state: "No local data — run Fetch new to start"
-- Refreshes in place after any pull — no app restart needed
-
-**Gmail MFA setup is now GUI-first**:
-- New Configure button on the Gmail MFA card opens a 3-step wizard — browse for `google_credentials.json`, open the authorization URL, paste the resulting code. Token exchange runs on a background thread so the UI stays responsive
-- "How do I get this?" link opens a help dialog with 7 numbered steps for obtaining an OAuth Desktop app credentials file from Google Cloud Console, plus an "Open Google Cloud Console" button
-- Reuses the same `requests_oauthlib` logic as `scripts/setup_gmail_auth.py`, so CLI and GUI stay in sync
-
-**Drive / Sheets export refinements**:
-- Clearer checkbox copy: **Archive raw CSV files to Google Drive** vs **Populate Google Sheet with data (for viewing/charting)**
-- Small `?` help popovers next to each option explain the difference — archival raw files versus live dashboard
-- Local-save note under the checkboxes: CSVs are always saved to `reports/` first; the export options are additive
-- **Hierarchical Drive folder picker**. Browse from My Drive down into subfolders, filter within the current level, click "Select this folder" to choose any level. Replaces the previous flat listing that capped at 200 folders and was slow to scroll
-- README §5 rewritten with an "archival vs live dashboard" framing and a "which do I pick" decision table
-
-**Auto-login resilience**:
-- New `_probe_email_field()` checks URL, selector presence, and whether the field is empty before attempting to type. If anything looks off — slow page load, user already typing, Cloudflare interstitial — `_do_login` hands off to `_wait_for_manual_login` instead of the 10-second blind wait that previously ended in a `NoSuchElementException`
-- Top-level exception handler in `ensure_logged_in` surfaces failures as a single-line readable error plus a screenshot path to stderr, rather than a raw Python traceback in the GUI log panel
-
-**Security**:
-- MFA code is no longer printed to logs on successful Gmail retrieval. The one-time code was appearing verbatim in GUI log panels and cron log files — replaced with "MFA obtained."
-
-**GUI plumbing fixes**:
-- Automation page wrapped in a `QScrollArea` so content overflow no longer compresses every action button to unreadable height
-- Action buttons now have `setMinimumHeight(32)` as a defensive floor
-- Latest Sync label renders fully on first paint — CSS padding on a `QLabel` doesn't show up in `sizeHint`, so padding was moved from the stylesheet into layout spacing
-- `_is_tui_capable()` no longer checks `TERM` on Windows (PowerShell and cmd don't set it; Textual works fine there)
-
-**Known issue**:
-- Chrome may fail with "failed to close window in 20 seconds" on startup during SeleniumBase UC mode's close / reopen cycle. Brave and Edge work cleanly. Tracked in #74 — under investigation. If you hit it, switching the browser detection order (Brave installed alongside Chrome) is the current workaround.
-
----
-
-### v1.3.0 — 2026-04-15 — Navigation, keyring credentials, Fetch New
-
-**Keyboard navigation across all menus** (↑↓ / j/k / enter):
-- Every menu screen — Main Menu, Pull Data, Setup, Automation, Drive/Sheets — now supports arrow keys, vim motions (`j/k`), and `enter` to select, in addition to existing number shortcuts
-
-**Keyring-first credential storage:**
-- Passwords are now saved to the OS keyring (SecretService on Linux, Credential Manager on Windows, Keychain on macOS) by default — encrypted at rest, never written to disk
-- If no secure keyring backend is available, `.env` storage is offered with a prominent plaintext warning
-- Third option: runtime-only entry — enter credentials before each pull, nothing saved anywhere
-- Setup screen detects keyring availability on mount and adjusts the UI accordingly
-
-**Fetch New** (Pull Data → `[0]`):
-- Scans `data/garmin/` for the most recent local date, computes the gap to yesterday, and launches a pull automatically — no manual date selection required
-- If already up to date, shows a toast notification
-- If no local data exists yet, falls through to the Full History prompt
-
-**Bug fixes:**
-- `b` back is now always visible and functional during an active pull — pressing it terminates the subprocess and returns to the menu immediately
-- Gmail `is_configured()` now checks that the OAuth token contains the `gmail.readonly` scope, not just that the token file exists — prevents a 90-second polling wait when only Drive/Sheets OAuth has been completed
-- Fixed `AttributeError: 'DataPullScreen' object has no attribute '_cursor'` crash on screen open
-
----
-
-### v1.2.0 — 2026-04-15 — Google Drive / Sheets export
-
-**Google Drive / Sheets export** (Automation → Google Drive / Sheets):
-- Upload `garmin_daily.csv` and `garmin_activities.csv` to a Google Drive folder — creates `Garmin Extract/` on first run, updates files in-place on subsequent runs
-- Sync data to a `Garmin Data` Google Sheet with `Daily` and `Activities` tabs — creates the spreadsheet on first run, clears and rewrites on each sync
-- "Both" option runs Drive upload and Sheets sync in sequence
-- Auth status and last-export timestamp shown on screen mount; folder/sheet IDs persisted in `.drive_config.json` so exports always update the same resources
-- Reuses the existing Gmail OAuth token (same `google_credentials.json` / `.google_token.json`) — no additional OAuth setup required if Gmail MFA was already configured
-
----
-
-### v1.1.0 — 2026-04-14 — Full TUI, expanded API, setup wizard, automation
-
-**Full Textual TUI** replacing the print menu as the primary interface:
-- `MainMenuScreen` → `DataPullScreen` → `PullProgressScreen` with live per-metric or per-day progress depending on date range
-- MFA modal inside the TUI — prompts for a code when Gmail automation is not available
-- `Initial Setup` screen with prerequisite checks, Garmin credential management, and Gmail OAuth wizard (including in-dialog URL display for headless environments)
-- `Automation` screen with Gmail MFA status view and `Scheduled Pulls` manager (enable, disable, change pull time)
-
-**Expanded Garmin API coverage:**
-- Added nutrition (food log, meals), menstrual cycle tracking
-- Per-activity detail: 8 endpoints per logged workout (splits, HR/power zones, exercise sets, weather)
-- One-time profile pull per session: devices, personal records, training plans, workouts, gear → `profile.json`
-
-**Bug fixes:**
-- Fixed Python output buffering (`-u` flag) that caused subprocess output to stall in the TUI
-- Fixed `call_from_thread` usage in Textual screen workers
-- Fixed Gmail MFA CSS hex color false-match (`#000000` no longer matched as a security code)
-
----
-
-### 2026-04-09 — CSV normalization and lifestyle logging fix
-
-**Human-readable column headers:** All columns in `garmin_daily.csv` and `garmin_activities.csv` now use plain English names with units in parentheses (e.g. `Resting Heart Rate (bpm)`, `Deep Sleep (seconds)`, `Floors Ascended (meters)`).
-
-**Lifestyle logging fix:** The lifestyle behavior extraction was reading from the wrong part of the JSON structure and silently producing empty columns. It now correctly reads from `lifestyle.dailyLogsReport[]`. Logged behaviors appear as `Yes`/`No` per day; behaviors not logged on a given day show `N/A`. Quantity-tracked behaviors (e.g. Alcohol) also get an `(amount)` column with the summed value. Behavior columns are discovered dynamically from the user's actual data — no behavior names are hardcoded.
-
-**Sleep timestamps:** `Sleep Start (UTC)` and `Sleep End (UTC)` were previously stored as raw millisecond epoch values. They are now converted to ISO 8601 strings (`YYYY-MM-DDTHH:MM:SSZ`).
-
----
-
-### 2026-04-08 — Gmail MFA false-match and re-submission loop fixes
-
-Two bugs were found and fixed in production after the initial deployment.
-
-#### Gmail MFA: CSS hex color false-match (`pullers/_gmail_mfa.py`)
-
-**Symptom:** The Gmail MFA poller was extracting `000000` from old Garmin emails instead of the real 6-digit code, then submitting it repeatedly.
-
-**Root causes:**
-1. `_get_message_text()` was returning the HTML part of the email before the plain-text part. Garmin emails include `#000000` (black CSS color) in their HTML body, and the fallback `\b(\d{6})\b` regex matched the hex digits.
-2. The poll loop had no memory of which emails it had already processed — so if the first poll returned a bad email, every subsequent poll would find and re-process it.
-
-**Fixes:**
-- `_get_message_text()` now explicitly prefers `text/plain` over `text/html`.
-- The fallback regex is now `(?<!#)\b(\d{6})\b` — a negative lookbehind that excludes CSS hex colors.
-- Codes where all digits are identical (`000000`, `111111`, etc.) are rejected outright.
-- `wait_for_mfa_gmail()` maintains a `seen_ids` set — each message ID is only processed once per poll session.
-- The `after:` Gmail search filter now uses the exact script start time with no buffer, preventing stale emails from surfacing.
-
-#### MFA re-submission loop (`pullers/garmin.py`)
-
-**Symptom:** After a valid MFA code was submitted, the login poll loop continued iterating. On slow redirects, it found the MFA input again and called `wait_for_mfa()` a second time — submitting a fresh (and wrong) code. Combined with the Gmail bug above, this produced 8+ failed submissions per login attempt.
-
-**Fix:** Both MFA code paths (URL-based `/mfa` detection and selector-based detection) now wait up to 15 seconds for the browser to redirect away from the MFA page before continuing. A `break` after submission ensures `wait_for_mfa()` is called at most once per login attempt.
-
-**Verified in production:** Garmin pull for 2026-04-08 completed successfully. MFA code `184037` was extracted from Gmail on the first try, login completed in a single pass, and all 25 metrics were pulled.
+Full release history is on the [Changelog wiki page](https://github.com/ColonelPanicX/garmin-extract/wiki/Changelog).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" \
     | sudo tee /etc/apt/sources.list.d/google-chrome.list
 sudo apt update && sudo apt install -y google-chrome-stable
 
-# Install Xvfb (virtual display — required for headless Chrome)
-sudo apt install -y xvfb
-
 # Install garmin-extract
 git clone https://github.com/ColonelPanicX/garmin-extract.git
 cd garmin-extract
@@ -62,7 +59,7 @@ uv sync
 uv run python -m garmin_extract
 ```
 
-The app auto-starts Xvfb when needed, but the `xvfb` binary must be installed first.
+On first launch, the TUI detects headless Linux and walks you through the remaining prerequisites (Xvfb install, Garmin credentials, Gmail MFA). Because there's no display for a manual login, **all three must be configured** before a pull can run — the preflight gates the **Continue** button until everything is green. The TUI can install Xvfb on apt/dnf/pacman/apk systems; on unrecognized distros, install `xvfb` (or your distro's equivalent) manually.
 
 ## First-time setup
 

--- a/garmin_extract/_credentials.py
+++ b/garmin_extract/_credentials.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from garmin_extract._paths import app_root
 
 _SERVICE = "garmin-extract"
@@ -76,13 +78,24 @@ def save_to_keyring(email: str, password: str) -> tuple[bool, str]:
 
 
 def save_to_env(email: str, password: str) -> None:
-    """Write credentials to .env (plaintext)."""
+    """Write credentials to .env (plaintext). Sets 0600 perms on POSIX."""
     lines = [
         "# Garmin Connect credentials",
         f"GARMIN_EMAIL={email}",
         f"GARMIN_PASSWORD={password}",
     ]
     ENV_FILE.write_text("\n".join(lines) + "\n")
+    _lock_down_env(ENV_FILE)
+
+
+def _lock_down_env(path) -> None:
+    """chmod 600 on POSIX so the .env is only readable by the owning user."""
+    if os.name != "posix":
+        return
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
 
 
 def check_credentials() -> tuple[bool, str]:
@@ -153,6 +166,7 @@ def _scrub_env() -> None:
         ENV_FILE.unlink()
     else:
         ENV_FILE.write_text("\n".join(kept) + "\n")
+        _lock_down_env(ENV_FILE)
 
 
 def _load_from_env() -> tuple[str, str]:

--- a/garmin_extract/_xvfb.py
+++ b/garmin_extract/_xvfb.py
@@ -1,0 +1,69 @@
+"""Xvfb detection and install helpers — shared across menu, TUI setup, and CLI.
+
+The "truly headless" check is cached at first call so that later callers still
+see the original state after Xvfb has exported DISPLAY into the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+from pathlib import Path
+
+_OS_RELEASE = Path("/etc/os-release")
+_truly_headless: bool | None = None
+
+
+def is_installed() -> bool:
+    return shutil.which("Xvfb") is not None
+
+
+def is_truly_headless() -> bool:
+    """True when we started on Linux with no $DISPLAY — cached for the process lifetime."""
+    global _truly_headless
+    if _truly_headless is None:
+        _truly_headless = platform.system() == "Linux" and not os.environ.get("DISPLAY")
+    return _truly_headless
+
+
+def detect_install_cmd() -> tuple[list[str], str]:
+    """Return (argv, human-readable string) for installing Xvfb on this distro."""
+    ids: set[str] = set()
+    if _OS_RELEASE.exists():
+        for line in _OS_RELEASE.read_text().splitlines():
+            if "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            v = v.strip().strip('"')
+            if k == "ID":
+                ids.add(v)
+            elif k == "ID_LIKE":
+                ids.update(v.split())
+
+    if ids & {"debian", "ubuntu"}:
+        argv = ["sudo", "apt-get", "install", "-y", "xvfb"]
+    elif ids & {"fedora", "rhel", "centos"}:
+        argv = ["sudo", "dnf", "install", "-y", "xorg-x11-server-Xvfb"]
+    elif ids & {"arch"}:
+        argv = ["sudo", "pacman", "-S", "--noconfirm", "xorg-server-xvfb"]
+    elif ids & {"alpine"}:
+        argv = ["sudo", "apk", "add", "xvfb"]
+    else:
+        argv = ["sudo", "apt-get", "install", "-y", "xvfb"]
+    return argv, " ".join(argv)
+
+
+def install() -> tuple[bool, str]:
+    """Run the detected install command. Returns (ok, detail)."""
+    argv, human = detect_install_cmd()
+    try:
+        r = subprocess.run(argv, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        return False, f"Package manager not found: {exc}"
+    if r.returncode == 0 and is_installed():
+        return True, "Installed"
+    detail = (r.stderr or r.stdout or "").strip().splitlines()
+    last = detail[-1] if detail else f"exit {r.returncode}"
+    return False, f"{human} failed — {last}"

--- a/garmin_extract/menu.py
+++ b/garmin_extract/menu.py
@@ -164,11 +164,9 @@ def _find_chrome() -> tuple[bool, str | None]:
 
 
 def _find_xvfb() -> bool:
-    try:
-        r = subprocess.run(["which", "Xvfb"], capture_output=True, timeout=5)
-        return r.returncode == 0
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
-        return False
+    from garmin_extract._xvfb import is_installed
+
+    return is_installed()
 
 
 def _missing_packages() -> list[str]:
@@ -350,17 +348,20 @@ def check_prerequisites() -> None:  # noqa: C901
             print("  Xvfb (X Virtual Framebuffer) creates a fake, hidden screen")
             print("  so Chrome has somewhere to render without a real display.")
             print()
+            from garmin_extract._xvfb import detect_install_cmd, install
+
+            _, install_str = detect_install_cmd()
             print("  We can install it now:")
-            print("    sudo apt-get install -y xvfb")
+            print(f"    {install_str}")
             print()
             go = prompt_with_navigation("  Install Xvfb now? [Y/n]: ")
             if go.lower() != "n":
                 print()
-                r = subprocess.run(["sudo", "apt-get", "install", "-y", "xvfb"])
-                if r.returncode == 0 and _find_xvfb():
+                ok, detail = install()
+                if ok:
                     console.print("\n  [green]✓[/]  Xvfb installed.")
                 else:
-                    console.print("\n  [red]✗[/]  Installation may not have completed.")
+                    console.print(f"\n  [red]✗[/]  Installation failed: {detail}")
                     issues.append("Xvfb")
             else:
                 print()

--- a/garmin_extract/screens/data_pull.py
+++ b/garmin_extract/screens/data_pull.py
@@ -13,6 +13,30 @@ from textual.widgets import Footer, Header, Input, Static
 _SECTION = "  [bold dim]{title}[/]\n  " + "─" * 51
 
 
+def _launch_pull(app, **kwargs) -> None:
+    """Push PullProgressScreen, gating on LinuxPreflightScreen when relevant."""
+    import platform
+
+    from garmin_extract.screens.pull_progress import PullProgressScreen
+
+    def _go() -> None:
+        app.push_screen(PullProgressScreen(**kwargs))
+
+    skip_preflight = kwargs.get("rebuild_only") or kwargs.get("zip_path")
+    if skip_preflight or platform.system() != "Linux":
+        _go()
+        return
+
+    from garmin_extract.screens.linux_preflight import LinuxPreflightScreen
+
+    def _after(result: str | None) -> None:
+        if result is None:
+            return
+        _go()
+
+    app.push_screen(LinuxPreflightScreen(), _after)
+
+
 def _date_range_label(days: int) -> str:
     today = date.today()
     start = today - timedelta(days=days)
@@ -182,16 +206,13 @@ class DataPullScreen(Screen[None]):
         no_skip: bool = False,
         rebuild_only: bool = False,
     ) -> None:
-        from garmin_extract.screens.pull_progress import PullProgressScreen
-
-        self.app.push_screen(
-            PullProgressScreen(
-                start_date=start_date,
-                days=days,
-                label=label,
-                no_skip=no_skip,
-                rebuild_only=rebuild_only,
-            )
+        _launch_pull(
+            self.app,
+            start_date=start_date,
+            days=days,
+            label=label,
+            no_skip=no_skip,
+            rebuild_only=rebuild_only,
         )
 
     def action_fetch_new(self) -> None:
@@ -340,11 +361,12 @@ class CustomDateScreen(_InputScreen):
         self._push_pull(start, days)
 
     def _push_pull(self, start: str, days: int) -> None:
-        from garmin_extract.screens.pull_progress import PullProgressScreen
-
         self.app.pop_screen()
-        self.app.push_screen(
-            PullProgressScreen(start_date=start, days=days, label=f"Custom  ({start}, {days}d)")
+        _launch_pull(
+            self.app,
+            start_date=start,
+            days=days,
+            label=f"Custom  ({start}, {days}d)",
         )
 
 
@@ -381,15 +403,12 @@ class FullHistoryScreen(_InputScreen):
             error.update("Start date must be before today.")
             return
 
-        from garmin_extract.screens.pull_progress import PullProgressScreen
-
         self.app.pop_screen()
-        self.app.push_screen(
-            PullProgressScreen(
-                start_date=start,
-                days=days,
-                label=f"Full history  ({start} → {yesterday.isoformat()})",
-            )
+        _launch_pull(
+            self.app,
+            start_date=start,
+            days=days,
+            label=f"Full history  ({start} → {yesterday.isoformat()})",
         )
 
 
@@ -421,14 +440,11 @@ class ImportZipScreen(_InputScreen):
             error.update(f"File not found: {raw}")
             return
 
-        from garmin_extract.screens.pull_progress import PullProgressScreen
-
         self.app.pop_screen()
-        self.app.push_screen(
-            PullProgressScreen(
-                start_date="",
-                days=0,
-                label="Garmin bulk export import",
-                zip_path=raw,
-            )
+        _launch_pull(
+            self.app,
+            start_date="",
+            days=0,
+            label="Garmin bulk export import",
+            zip_path=raw,
         )

--- a/garmin_extract/screens/linux_preflight.py
+++ b/garmin_extract/screens/linux_preflight.py
@@ -1,0 +1,332 @@
+"""Linux preflight — gates pulls on Xvfb, Garmin creds, and Gmail MFA.
+
+On truly-headless Linux (no $DISPLAY) the pull cannot proceed without all
+three: Xvfb installed, Garmin credentials saved, and Gmail MFA configured
+(manual login is impossible with no screen to interact with). On desktop
+Linux the user may still choose manual login as on Windows/macOS.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Static
+
+ROOT = Path(__file__).parent.parent.parent
+GMAIL_CREDS_FILE = ROOT / "google_credentials.json"
+GMAIL_TOKEN_FILE = ROOT / ".google_token.json"
+
+
+def _gmail_configured() -> bool:
+    return GMAIL_CREDS_FILE.exists() and GMAIL_TOKEN_FILE.exists()
+
+
+class LinuxPreflightScreen(ModalScreen[str | None]):
+    """Modal that gates a pull on Linux prerequisites.
+
+    Dismissed values:
+      - "manual"  — user chose manual login (DISPLAY available only)
+      - "auto"    — all required prerequisites satisfied, proceed with auto login
+      - None      — user cancelled
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=True)]
+
+    CSS = """
+    LinuxPreflightScreen {
+        align: center middle;
+    }
+
+    #preflight-box {
+        width: 72;
+        height: auto;
+        max-height: 90%;
+        border: round $accent;
+        padding: 1 2;
+    }
+
+    #preflight-title {
+        text-style: bold;
+        color: $accent;
+        margin-bottom: 1;
+    }
+
+    #preflight-hint {
+        color: $text-muted;
+        margin-bottom: 1;
+    }
+
+    .gate-row {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    .gate-status {
+        height: auto;
+    }
+
+    .gate-actions {
+        height: auto;
+        margin-top: 0;
+    }
+
+    #creds-form {
+        height: auto;
+        display: none;
+        padding: 1 0;
+    }
+
+    #creds-form.visible {
+        display: block;
+    }
+
+    #creds-error {
+        color: $error;
+        height: auto;
+    }
+
+    #preflight-buttons {
+        height: auto;
+        margin-top: 1;
+    }
+
+    Button {
+        margin-right: 1;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._creds_visible = False
+
+    # ── state helpers ────────────────────────────────────────────────────
+
+    def _is_headless(self) -> bool:
+        from garmin_extract._xvfb import is_truly_headless
+
+        return is_truly_headless()
+
+    def _xvfb_needed(self) -> bool:
+        return self._is_headless()
+
+    def _xvfb_ok(self) -> bool:
+        from garmin_extract._xvfb import is_installed
+
+        return is_installed()
+
+    def _creds_ok(self) -> bool:
+        from garmin_extract._credentials import load_credentials
+
+        email, password = load_credentials()
+        return bool(email and password)
+
+    def _mfa_ok(self) -> bool:
+        return _gmail_configured()
+
+    def _can_proceed_auto(self) -> bool:
+        """All required gates must be green."""
+        if self._xvfb_needed() and not self._xvfb_ok():
+            return False
+        if self._is_headless():
+            return self._creds_ok() and self._mfa_ok()
+        return self._creds_ok()
+
+    # ── compose ──────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="preflight-box"):
+            yield Static("Linux Preflight", id="preflight-title")
+            yield Static("", id="preflight-hint")
+
+            # Xvfb row (only meaningful when headless)
+            with Vertical(classes="gate-row", id="xvfb-row"):
+                yield Static("", id="xvfb-status", classes="gate-status")
+                with Horizontal(classes="gate-actions", id="xvfb-actions"):
+                    yield Button("Install Xvfb", id="install-xvfb", variant="primary")
+
+            # Credentials row
+            with Vertical(classes="gate-row", id="creds-row"):
+                yield Static("", id="creds-status", classes="gate-status")
+                with Horizontal(classes="gate-actions", id="creds-actions"):
+                    yield Button("Configure auto login", id="configure-creds")
+                with Vertical(id="creds-form"):
+                    yield Input(placeholder="Garmin email", id="creds-email")
+                    yield Input(
+                        placeholder="Garmin password",
+                        id="creds-password",
+                        password=True,
+                    )
+                    yield Static("", id="creds-error")
+                    with Horizontal():
+                        yield Button("Save", id="save-creds", variant="primary")
+                        yield Button("Cancel", id="cancel-creds")
+
+            # Gmail MFA row
+            with Vertical(classes="gate-row", id="mfa-row"):
+                yield Static("", id="mfa-status", classes="gate-status")
+                with Horizontal(classes="gate-actions", id="mfa-actions"):
+                    yield Button("Configure Gmail MFA", id="configure-mfa")
+
+            # Action row
+            with Horizontal(id="preflight-buttons"):
+                yield Button("Log in manually", id="manual", variant="success")
+                yield Button("Continue", id="continue", variant="primary")
+                yield Button("Cancel", id="cancel")
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        self._refresh()
+
+    def on_screen_resume(self) -> None:
+        # Re-run when returning from the pushed GmailSetupScreen
+        self._refresh()
+
+    def _refresh(self) -> None:
+        headless = self._is_headless()
+
+        hint = (
+            "Headless Linux — automation requires Xvfb, saved Garmin credentials, "
+            "and Gmail MFA. Manual login is unavailable without a display."
+            if headless
+            else "Choose how to log in. Auto login saves your credentials to the OS "
+            "keyring for future unattended runs."
+        )
+        self.query_one("#preflight-hint", Static).update(hint)
+
+        # ── Xvfb
+        xvfb_row = self.query_one("#xvfb-row", Vertical)
+        if self._xvfb_needed():
+            xvfb_row.display = True
+            ok = self._xvfb_ok()
+            self.query_one("#xvfb-status", Static).update(
+                "[green]✓[/]  Xvfb installed"
+                if ok
+                else "[red]✗[/]  Xvfb not installed — required for headless Chrome"
+            )
+            self.query_one("#install-xvfb", Button).display = not ok
+        else:
+            xvfb_row.display = False
+
+        # ── Credentials
+        creds_ok = self._creds_ok()
+        creds_required = headless
+        creds_label = (
+            "[green]✓[/]  Garmin credentials saved"
+            if creds_ok
+            else (
+                "[red]✗[/]  Garmin credentials not configured — required for headless"
+                if creds_required
+                else "[yellow]○[/]  Garmin credentials not configured (optional)"
+            )
+        )
+        self.query_one("#creds-status", Static).update(creds_label)
+        self.query_one("#configure-creds", Button).display = not self._creds_visible
+
+        # ── Gmail MFA
+        mfa_row = self.query_one("#mfa-row", Vertical)
+        if headless:
+            mfa_row.display = True
+            mfa_ok = self._mfa_ok()
+            self.query_one("#mfa-status", Static).update(
+                "[green]✓[/]  Gmail MFA configured"
+                if mfa_ok
+                else "[red]✗[/]  Gmail MFA not configured — required for headless"
+            )
+        else:
+            mfa_row.display = False
+
+        # ── Buttons
+        self.query_one("#manual", Button).display = not headless
+        self.query_one("#continue", Button).disabled = not self._can_proceed_auto()
+
+    # ── events ───────────────────────────────────────────────────────────
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        bid = event.button.id
+        if bid == "cancel":
+            self.dismiss(None)
+        elif bid == "manual":
+            self.dismiss("manual")
+        elif bid == "continue":
+            if self._can_proceed_auto():
+                self.dismiss("auto")
+        elif bid == "install-xvfb":
+            self._install_xvfb()
+        elif bid == "configure-creds":
+            self._show_creds_form()
+        elif bid == "cancel-creds":
+            self._hide_creds_form()
+        elif bid == "save-creds":
+            self._save_creds()
+        elif bid == "configure-mfa":
+            self._open_mfa_setup()
+
+    def _install_xvfb(self) -> None:
+        btn = self.query_one("#install-xvfb", Button)
+        btn.disabled = True
+        btn.label = "Installing…"
+        self.run_worker(self._xvfb_worker, thread=True, exclusive=True)
+
+    def _xvfb_worker(self) -> None:
+        from garmin_extract._xvfb import install
+
+        ok, detail = install()
+        self.app.call_from_thread(self._xvfb_done, ok, detail)
+
+    def _xvfb_done(self, ok: bool, detail: str) -> None:
+        btn = self.query_one("#install-xvfb", Button)
+        btn.disabled = False
+        btn.label = "Install Xvfb"
+        if not ok:
+            self.notify(detail, severity="error", title="Xvfb install failed")
+        self._refresh()
+
+    def _show_creds_form(self) -> None:
+        self._creds_visible = True
+        self.query_one("#creds-form").add_class("visible")
+        self.query_one("#configure-creds", Button).display = False
+        from garmin_extract._credentials import load_credentials
+
+        email, _ = load_credentials()
+        if email:
+            self.query_one("#creds-email", Input).value = email
+        self.query_one("#creds-email", Input).focus()
+
+    def _hide_creds_form(self) -> None:
+        self._creds_visible = False
+        self.query_one("#creds-form").remove_class("visible")
+        self.query_one("#creds-error", Static).update("")
+        self._refresh()
+
+    def _save_creds(self) -> None:
+        email = self.query_one("#creds-email", Input).value.strip()
+        password = self.query_one("#creds-password", Input).value.strip()
+        err = self.query_one("#creds-error", Static)
+        if not email or not password:
+            err.update("Email and password are required.")
+            return
+        from garmin_extract._credentials import detect_keyring, save_to_env, save_to_keyring
+
+        keyring_ok, _ = detect_keyring()
+        if keyring_ok:
+            ok, detail = save_to_keyring(email, password)
+            if not ok:
+                err.update(f"Keyring save failed: {detail}")
+                return
+        else:
+            save_to_env(email, password)
+        err.update("")
+        self._hide_creds_form()
+
+    def _open_mfa_setup(self) -> None:
+        from garmin_extract.screens.setup import GmailSetupScreen
+
+        self.app.push_screen(GmailSetupScreen())
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/garmin_extract/screens/setup.py
+++ b/garmin_extract/screens/setup.py
@@ -41,9 +41,9 @@ def _check_xvfb() -> tuple[bool, str]:
 
     if os.environ.get("DISPLAY"):
         return True, "Not needed — display available"
-    from garmin_extract.menu import _find_xvfb
+    from garmin_extract._xvfb import is_installed
 
-    found = _find_xvfb()
+    found = is_installed()
     return found, "Installed" if found else "Not found"
 
 
@@ -550,9 +550,12 @@ class _InstallScreen(Screen[None]):
                 proc.wait()
 
         if self._states.get("Xvfb") == "fail":
+            from garmin_extract._xvfb import detect_install_cmd
+
+            argv, _ = detect_install_cmd()
             self.app.call_from_thread(log.write, "\n[bold]Installing Xvfb…[/bold]")
             proc = subprocess.Popen(
-                ["sudo", "apt-get", "install", "-y", "xvfb"],
+                argv,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,

--- a/pullers/_gmail_mfa.py
+++ b/pullers/_gmail_mfa.py
@@ -134,18 +134,22 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
         elapsed += poll_interval
 
         try:
-            # Search for Garmin MFA emails received since script start
+            # Search for Garmin MFA emails received since script start.
+            # Garmin currently sends from alerts@account.garmin.com with subject
+            # "Your Security Passcode"; older runs used noreply@garmin.com.
+            # Gmail tokenizes on word boundaries, so "passcode" must be listed
+            # explicitly — "code" does not match "Passcode".
             query = (
-                f"from:noreply@garmin.com "
+                f"from:(noreply@garmin.com OR alerts@account.garmin.com) "
                 f"after:{start_epoch_s} "
-                f"subject:(security code OR verification OR sign-in)"
+                f"subject:(security code OR passcode OR verification OR sign-in)"
             )
             result = service.users().messages().list(userId="me", q=query, maxResults=5).execute()
 
             messages = result.get("messages", [])
             if not messages:
-                # Broader fallback — any recent garmin.com email
-                query2 = f"from:garmin.com after:{start_epoch_s}"
+                # Broader fallback — any recent email from a garmin.com domain.
+                query2 = f"from:(garmin.com OR account.garmin.com) after:{start_epoch_s}"
                 result2 = (
                     service.users().messages().list(userId="me", q=query2, maxResults=5).execute()
                 )

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -67,6 +68,18 @@ from garmin_extract._browser import detect_windows_browser  # noqa: E402
 
 
 def start_xvfb(display=":99"):
+    if shutil.which("Xvfb") is None:
+        from garmin_extract._xvfb import detect_install_cmd
+
+        _, install_str = detect_install_cmd()
+        print("ERROR: Xvfb is required on headless Linux but is not installed.")
+        print(f"  Install it with:  {install_str}")
+        print("  Then re-run this command.")
+        print(
+            "  (Or run the TUI —  uv run python -m garmin_extract  — "
+            "which can install Xvfb for you.)"
+        )
+        sys.exit(1)
     proc = subprocess.Popen(
         ["Xvfb", display, "-screen", "0", "1280x720x24"],
         stdout=subprocess.DEVNULL,

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -153,11 +153,6 @@ def ensure_logged_in(sb, email: str = "", password: str = "") -> None:
     If email/password are provided, login is automated. Otherwise the browser
     opens to the login page and waits for the user to log in manually.
     """
-    # Remove stale Chrome lock files that prevent profile reuse
-    lock = PROFILE_DIR / "SingletonLock"
-    if lock.exists():
-        lock.unlink()
-
     sb.uc_open_with_reconnect("https://connect.garmin.com/modern/", reconnect_time=3)
     sb.sleep(3)
 
@@ -725,9 +720,19 @@ def main():
     try:
         print("Launching browser...")
         PROFILE_DIR.mkdir(exist_ok=True)
+        # Clear any stale Chrome singleton files from a prior crashed run. Chrome treats
+        # leftover SingletonSocket/SingletonCookie as "another instance is already using
+        # this profile" and exits before ChromeDriver can connect.
+        for stale in PROFILE_DIR.glob("Singleton*"):
+            stale.unlink(missing_ok=True)
         # headless=False required — UC mode's uc_open_with_reconnect closes and reopens the
         # Chrome window as part of its Cloudflare bypass; headless mode breaks that mechanism.
         sb_kwargs = dict(uc=True, headless=False, xvfb=False, user_data_dir=str(PROFILE_DIR))
+        if platform.system() == "Linux":
+            # KVM/container guests commonly lack unprivileged user-namespaces, so Chrome's
+            # sandbox can't initialize; /dev/shm is also frequently undersized. Comma-separated
+            # because SeleniumBase splits chromium_arg on "," (not whitespace).
+            sb_kwargs["chromium_arg"] = "--no-sandbox,--disable-dev-shm-usage"
         if browser_bin:
             sb_kwargs["binary_location"] = browser_bin
         with SB(**sb_kwargs) as sb:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "garmin-extract"
-version = "1.6.0"
+version = "1.6.1"
 description = "Automated Garmin Connect data pipeline using browser automation"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.4.3"
+version = "1.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.6.0"
+version = "1.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

Release PR folding `dev` into `main` for **v1.6.1**. Cut after a real-world headless Linux test run on a fresh KVM guest surfaced several blockers unnoticed in v1.6.0.

## Included changes

- **#82** — Linux preflight modal (TUI); `garmin_extract/_xvfb.py` shared helpers (apt/dnf/pacman/apk install detection); `chmod 0600` on `.env` writes; Chrome `--no-sandbox,--disable-dev-shm-usage` on Linux; pre-launch `Singleton*` cleanup
- **#84** — Gmail MFA query widened to match `alerts@account.garmin.com` + `Your Security Passcode` subject; explicit subdomain in fallback query

## Test plan

- [x] `ruff check .` + `black --check .` clean
- [x] TUI smoke test on dev Linux: preflight modal pushes, cancels cleanly, gate logic correct
- [x] Simulated missing-Xvfb CLI exits 1 with distro-aware install command
- [x] End-to-end on headless KVM guest (separate tester agent): pull completes, all 28 metrics written, Gmail MFA caught on first poll, exit 0
- [ ] Post-merge: tag `v1.6.1`, draft GitHub release, update wiki Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)