### PR TITLE
fix: cron-robustness trio — Gmail MFA race, orphan reap, session probe (#86)

### DIFF
--- a/pullers/_gmail_mfa.py
+++ b/pullers/_gmail_mfa.py
@@ -123,8 +123,12 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
 
     print("  [gmail] Polling inbox for Garmin MFA code...")
 
-    # Only look at emails received after this script started
+    # Only look at emails received after this script started. Gmail's after: filter
+    # is second-precision, so a matching email that arrived within the same second as
+    # start_epoch_s can slip through; we apply a strict ms-level internalDate filter
+    # below as the authoritative guard against stale codes from prior runs.
     start_epoch_s = int(time.time())
+    start_ms = start_epoch_s * 1000
     poll_interval = 5  # seconds between checks
     elapsed = 0
     seen_ids = set()  # never re-process the same email
@@ -155,19 +159,34 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
                 )
                 messages = result2.get("messages", [])
 
-            for msg in messages:
-                if msg["id"] in seen_ids:
-                    continue  # already tried this email
-                seen_ids.add(msg["id"])
+            # Enrich with internalDate, drop any email not strictly newer than start,
+            # and process newest-first so a fresh code always wins over a stale one.
+            fresh: list[tuple[str, int]] = []
+            for m in messages:
+                meta = (
+                    service.users()
+                    .messages()
+                    .get(userId="me", id=m["id"], format="minimal")
+                    .execute()
+                )
+                idate = int(meta.get("internalDate", 0))
+                if idate > start_ms:
+                    fresh.append((m["id"], idate))
+            fresh.sort(key=lambda pair: pair[1], reverse=True)
 
-                text = _get_message_text(service, msg["id"])
+            for msg_id, _ in fresh:
+                if msg_id in seen_ids:
+                    continue  # already tried this email
+                seen_ids.add(msg_id)
+
+                text = _get_message_text(service, msg_id)
                 code = _extract_code_from_text(text)
                 if code:
-                    print(f"  [gmail] Found MFA code in email (msg {msg['id'][:8]}...).")
+                    print(f"  [gmail] Found MFA code in email (msg {msg_id[:8]}...).")
                     return code
                 else:
                     print(
-                        f"  [gmail] Email found but no valid code extracted (msg {msg['id'][:8]}...)."  # noqa: E501
+                        f"  [gmail] Email found but no valid code extracted (msg {msg_id[:8]}...)."
                     )
 
             print(f"  [gmail] No code yet ({elapsed}s elapsed)...")

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -22,6 +22,7 @@ import json
 import os
 import platform
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -88,6 +89,40 @@ def start_xvfb(display=":99"):
     os.environ["DISPLAY"] = display
     time.sleep(1)
     return proc
+
+
+def _reap_profile_orphans(profile_dir: Path) -> None:
+    """Kill any Chrome/uc_driver still holding our profile from a prior crashed run.
+
+    Narrow match on the profile path — we only SIGKILL processes whose argv
+    references this specific user-data-dir, so unrelated Chrome sessions
+    (e.g. a dev's desktop browser) are untouched.
+    """
+    if shutil.which("pgrep") is None:
+        return
+    try:
+        r = subprocess.run(
+            ["pgrep", "-f", str(profile_dir)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return
+    if r.returncode != 0:
+        return
+    for pid_str in r.stdout.split():
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        if pid == os.getpid():
+            continue
+        try:
+            os.kill(pid, signal.SIGKILL)
+            print(f"  [cleanup] killed orphaned pid {pid} holding profile")
+        except (ProcessLookupError, PermissionError):
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -720,6 +755,10 @@ def main():
     try:
         print("Launching browser...")
         PROFILE_DIR.mkdir(exist_ok=True)
+        # Kill any orphaned Chrome/uc_driver still holding this profile from a
+        # prior crashed run. Without this, the new Chrome can't acquire the
+        # profile lock and times out with "failed to close window in 20 seconds".
+        _reap_profile_orphans(PROFILE_DIR)
         # Clear any stale Chrome singleton files from a prior crashed run. Chrome treats
         # leftover SingletonSocket/SingletonCookie as "another instance is already using
         # this profile" and exits before ChromeDriver can connect.

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -191,14 +191,25 @@ def ensure_logged_in(sb, email: str = "", password: str = "") -> None:
     sb.uc_open_with_reconnect("https://connect.garmin.com/modern/", reconnect_time=3)
     sb.sleep(3)
 
-    if "sign-in" in sb.get_current_url() or "sso.garmin.com" in sb.get_current_url():
-        if email and password:
-            print("Session expired or new — logging in...")
-            _do_login(sb, email, password)
-        else:
-            _wait_for_manual_login(sb)
+    url = sb.get_current_url()
+    on_signin = "sign-in" in url or "sso.garmin.com" in url
+
+    if not on_signin:
+        # URL looks authenticated, but the page shell can load from cache even
+        # when the session cookie has expired server-side. Probe the display-name
+        # API to confirm the session is actually valid before trusting it.
+        display_name, _ = get_display_name(sb)
+        if display_name:
+            print("Existing session active.")
+            return
+        print("Session cookie loads UI but API is rejecting — treating as expired.")
+        on_signin = True
+
+    if email and password:
+        print("Session expired or new — logging in...")
+        _do_login(sb, email, password)
     else:
-        print("Existing session active.")
+        _wait_for_manual_login(sb)
 
 
 def _wait_for_manual_login(sb) -> None:


### PR DESCRIPTION
## Summary

Three related bugs surfaced during a 10-day backfill run on a headless Linux cron VM after v1.6.1 shipped. They compound each other: orphaned processes cause retry loops, retry loops stack MFA emails, and stacked MFA emails + a race in the Gmail poll cause stale codes to be submitted.

Co-diagnosed with a separate tester agent via the agent-bridge troubleshooting room. Full transcript at \`/home/asimov/code/agent-bridge/garmin-extract-troubleshooting/\` for posterity.

## Commits

- \`84ab3ab\` — **Gmail MFA race**: strict \`internalDate > start_ms\` filter + explicit newest-first sort. Gmail's \`after:\` is second-precision and \`messages.list\` ordering isn't contractual; combined, an email one second before script start could win over the run's own fresh email. Observed on 2026-04-21: script started 12:42:15Z, poll returned email at 12:42:14Z from a prior failed run. Garmin's multi-minute MFA validity window masked the bug as a "lucky success".
- \`032009c\` — **Orphan reap**: \`pgrep -f PROFILE_DIR\` + SIGKILL before \`SB()\`. Handles Chrome/uc_driver processes that survive a crash and still hold the profile lock. Narrow path match avoids nuking unrelated Chrome on developer desktops. Explicit \`pid == os.getpid()\` guard against self-kill.
- \`747568f\` — **Session probe**: call \`get_display_name\` after URL check in \`ensure_logged_in\`. The Garmin app shell loads from cache even when the cookie is expired server-side; the URL check alone passes but every subsequent fetch returns status=0. One cheap API call gives us self-healing re-login.

## Test plan

- [x] \`ruff check .\` + \`black --check .\` clean
- [x] Unit behavior spot-checked: Gmail poll filters out emails with \`internalDate <= start_ms\`, reaper excludes own PID, session probe falls through to login when \`get_display_name\` returns empty
- [ ] End-to-end on headless Linux VM (tester): clean run with empty inbox, clean run with stacked MFA emails, run with orphaned Chrome from a prior kill -9, run with an expired-cookie profile

## Out of scope

- Orphan Xvfb cleanup — belongs in cron wrapper, too risky to kill globally from within the puller
- Retry logic within a single \`wait_for_mfa_gmail\` call after a rejected code
- Gmail OAuth refresh-token handling

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)