### PR TITLE
chore: release v1.6.2 — cron-robustness trio

### DIFF
--- a/pullers/_gmail_mfa.py
+++ b/pullers/_gmail_mfa.py
@@ -123,8 +123,12 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
 
     print("  [gmail] Polling inbox for Garmin MFA code...")
 
-    # Only look at emails received after this script started
+    # Only look at emails received after this script started. Gmail's after: filter
+    # is second-precision, so a matching email that arrived within the same second as
+    # start_epoch_s can slip through; we apply a strict ms-level internalDate filter
+    # below as the authoritative guard against stale codes from prior runs.
     start_epoch_s = int(time.time())
+    start_ms = start_epoch_s * 1000
     poll_interval = 5  # seconds between checks
     elapsed = 0
     seen_ids = set()  # never re-process the same email
@@ -155,19 +159,34 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
                 )
                 messages = result2.get("messages", [])
 
-            for msg in messages:
-                if msg["id"] in seen_ids:
-                    continue  # already tried this email
-                seen_ids.add(msg["id"])
+            # Enrich with internalDate, drop any email not strictly newer than start,
+            # and process newest-first so a fresh code always wins over a stale one.
+            fresh: list[tuple[str, int]] = []
+            for m in messages:
+                meta = (
+                    service.users()
+                    .messages()
+                    .get(userId="me", id=m["id"], format="minimal")
+                    .execute()
+                )
+                idate = int(meta.get("internalDate", 0))
+                if idate > start_ms:
+                    fresh.append((m["id"], idate))
+            fresh.sort(key=lambda pair: pair[1], reverse=True)
 
-                text = _get_message_text(service, msg["id"])
+            for msg_id, _ in fresh:
+                if msg_id in seen_ids:
+                    continue  # already tried this email
+                seen_ids.add(msg_id)
+
+                text = _get_message_text(service, msg_id)
                 code = _extract_code_from_text(text)
                 if code:
-                    print(f"  [gmail] Found MFA code in email (msg {msg['id'][:8]}...).")
+                    print(f"  [gmail] Found MFA code in email (msg {msg_id[:8]}...).")
                     return code
                 else:
                     print(
-                        f"  [gmail] Email found but no valid code extracted (msg {msg['id'][:8]}...)."  # noqa: E501
+                        f"  [gmail] Email found but no valid code extracted (msg {msg_id[:8]}...)."
                     )
 
             print(f"  [gmail] No code yet ({elapsed}s elapsed)...")

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -22,6 +22,7 @@ import json
 import os
 import platform
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -88,6 +89,40 @@ def start_xvfb(display=":99"):
     os.environ["DISPLAY"] = display
     time.sleep(1)
     return proc
+
+
+def _reap_profile_orphans(profile_dir: Path) -> None:
+    """Kill any Chrome/uc_driver still holding our profile from a prior crashed run.
+
+    Narrow match on the profile path — we only SIGKILL processes whose argv
+    references this specific user-data-dir, so unrelated Chrome sessions
+    (e.g. a dev's desktop browser) are untouched.
+    """
+    if shutil.which("pgrep") is None:
+        return
+    try:
+        r = subprocess.run(
+            ["pgrep", "-f", str(profile_dir)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return
+    if r.returncode != 0:
+        return
+    for pid_str in r.stdout.split():
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        if pid == os.getpid():
+            continue
+        try:
+            os.kill(pid, signal.SIGKILL)
+            print(f"  [cleanup] killed orphaned pid {pid} holding profile")
+        except (ProcessLookupError, PermissionError):
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -720,6 +755,10 @@ def main():
     try:
         print("Launching browser...")
         PROFILE_DIR.mkdir(exist_ok=True)
+        # Kill any orphaned Chrome/uc_driver still holding this profile from a
+        # prior crashed run. Without this, the new Chrome can't acquire the
+        # profile lock and times out with "failed to close window in 20 seconds".
+        _reap_profile_orphans(PROFILE_DIR)
         # Clear any stale Chrome singleton files from a prior crashed run. Chrome treats
         # leftover SingletonSocket/SingletonCookie as "another instance is already using
         # this profile" and exits before ChromeDriver can connect.

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -191,14 +191,25 @@ def ensure_logged_in(sb, email: str = "", password: str = "") -> None:
     sb.uc_open_with_reconnect("https://connect.garmin.com/modern/", reconnect_time=3)
     sb.sleep(3)
 
-    if "sign-in" in sb.get_current_url() or "sso.garmin.com" in sb.get_current_url():
-        if email and password:
-            print("Session expired or new — logging in...")
-            _do_login(sb, email, password)
-        else:
-            _wait_for_manual_login(sb)
+    url = sb.get_current_url()
+    on_signin = "sign-in" in url or "sso.garmin.com" in url
+
+    if not on_signin:
+        # URL looks authenticated, but the page shell can load from cache even
+        # when the session cookie has expired server-side. Probe the display-name
+        # API to confirm the session is actually valid before trusting it.
+        display_name, _ = get_display_name(sb)
+        if display_name:
+            print("Existing session active.")
+            return
+        print("Session cookie loads UI but API is rejecting — treating as expired.")
+        on_signin = True
+
+    if email and password:
+        print("Session expired or new — logging in...")
+        _do_login(sb, email, password)
     else:
-        print("Existing session active.")
+        _wait_for_manual_login(sb)
 
 
 def _wait_for_manual_login(sb) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "garmin-extract"
-version = "1.6.1"
+version = "1.6.2"
 description = "Automated Garmin Connect data pipeline using browser automation"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.6.1"
+version = "1.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

Release PR folding `dev` into `main` for **v1.6.2**. Cut after a headless-Linux cron VM backfill surfaced three quiet-until-they-bite robustness bugs in quick succession.

## Included changes

- **#87** — cron-robustness trio:
  - `84ab3ab` — Gmail MFA race: strict `internalDate > start_ms` filter + newest-first sort in `wait_for_mfa_gmail`
  - `032009c` — orphan Chrome/uc_driver reap via `pgrep -f PROFILE_DIR` before `SB()` launch
  - `747568f` — stale Garmin session detection via `get_display_name` probe in `ensure_logged_in`

## Test plan

- [x] `ruff check .` + `black --check .` clean
- [x] Orphan reap confirmed live on tester VM (9 PIDs cleaned; pull completed)
- [ ] Gmail MFA race fix — validated on code review; real-world verification via tomorrow's 6AM cron (can't synthetically test today without tripping Garmin's MFA rate limits again)
- [ ] Session probe — same story; natural validation as cookies expire over the next day or two
- [ ] Post-merge: tag `v1.6.2`, draft GitHub release, push wiki Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)