### PR TITLE
chore: sync main back into dev after v1.6.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "garmin-extract"
-version = "1.6.0"
+version = "1.6.1"
 description = "Automated Garmin Connect data pipeline using browser automation"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "garmin-extract"
-version = "1.6.1"
+version = "1.6.2"
 description = "Automated Garmin Connect data pipeline using browser automation"
 requires-python = ">=3.12"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.6.1"
+version = "1.6.2"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ wheels = [
 
 [[package]]
 name = "garmin-extract"
-version = "1.6.0"
+version = "1.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
## Summary

Syncs `main` into `dev` after the v1.6.2 release merge (#88). Without this, `dev` trails `main` on `pyproject.toml` (`uv.lock` tracks it), which means the next release branch would jump from an outdated baseline — same gap we had to paper over when cutting v1.6.2 (dev was at 1.6.0 while main was at 1.6.1).

Fast-forward merge — no conflicts, no new logic, just the version bump commit from the release branch.

## Test plan

- [x] `git merge origin/main` resolves as a fast-forward
- [x] `pyproject.toml` on the resulting dev will be `1.6.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)