### PR TITLE
fix(login): MFA anchor regression + UC reconnect omnibox frame (#90)

### DIFF
--- a/pullers/_gmail_mfa.py
+++ b/pullers/_gmail_mfa.py
@@ -106,7 +106,7 @@ def _get_message_text(service, msg_id: str) -> str:
     return plain or html
 
 
-def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
+def wait_for_mfa_gmail(timeout: int = 300, poll_start: float | None = None) -> str | None:
     """
     Poll Gmail for a Garmin MFA code. Returns the code string, or None
     if credentials are unavailable or the poll times out.
@@ -116,6 +116,9 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
 
     Args:
         timeout: seconds to poll before giving up (default 5 minutes)
+        poll_start: epoch seconds to use as the internalDate anchor instead of
+            now. Pass the script's import-time timestamp so emails sent during
+            browser startup (before this function is called) are not excluded.
     """
     service = _build_gmail_service()
     if not service:
@@ -123,11 +126,12 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
 
     print("  [gmail] Polling inbox for Garmin MFA code...")
 
-    # Only look at emails received after this script started. Gmail's after: filter
-    # is second-precision, so a matching email that arrived within the same second as
-    # start_epoch_s can slip through; we apply a strict ms-level internalDate filter
-    # below as the authoritative guard against stale codes from prior runs.
-    start_epoch_s = int(time.time())
+    # Anchor to poll_start (script import time) rather than now. Garmin sends
+    # the MFA email during the login sequence — 60–120s before this function is
+    # called on a typical headless VM. Using time.time() here sets start_ms in
+    # the future relative to the email's internalDate, causing the strict filter
+    # below to exclude the very email we're looking for.
+    start_epoch_s = int(poll_start) if poll_start is not None else int(time.time())
     start_ms = start_epoch_s * 1000
     poll_interval = 5  # seconds between checks
     elapsed = 0

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -46,6 +46,11 @@ DATA_DIR = ROOT / "data" / "garmin"
 PROFILE_DIR = ROOT / ".garmin_browser_profile"
 MFA_FILE = ROOT / ".mfa_code"
 RATE_LIMIT = 0.5  # seconds between API calls
+# Captured at import time (= script start). Passed to wait_for_mfa_gmail() so
+# the internalDate filter anchors to before browser startup, not after — Garmin
+# sends the MFA email during the login sequence, which completes 60–120s before
+# wait_for_mfa_gmail() is ever called.
+_PULL_START_S = int(time.time())
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +142,7 @@ def wait_for_mfa() -> str:
 
         if is_configured():
             print("MFA REQUIRED — polling Gmail automatically...")
-            code = wait_for_mfa_gmail(timeout=300)
+            code = wait_for_mfa_gmail(timeout=600, poll_start=_PULL_START_S)
             if code:
                 print("MFA obtained.")
                 return code
@@ -254,8 +259,18 @@ def _do_login(sb, email: str, password: str) -> None:
     sb.uc_open_with_reconnect(
         "https://sso.garmin.com/portal/sso/en-US/sign-in"
         "?clientId=GarminConnect&consumeServiceTicket=false",
-        reconnect_time=6,
+        reconnect_time=8,
     )
+    # UC reconnect on an already-open browser can leave ChromeDriver focused on
+    # a Chrome-internal frame (omnibox autocomplete popup). Iterate handles to
+    # land on the first real page context before probing the email field.
+    try:
+        for handle in sb.driver.window_handles:
+            sb.driver.switch_to.window(handle)
+            if not sb.get_current_url().startswith("chrome://"):
+                break
+    except Exception:
+        pass
     sb.sleep(5)
 
     ready, reason = _probe_email_field(sb)


### PR DESCRIPTION
Fixes #90

Two bugs that together block fully-automated headless re-login when the Garmin session has expired. Both diagnosed via agent-bridge with a live tester on a KVM VM; workarounds confirmed before this PR was written.

## Bug 1 — MFA poll anchor set too late

`wait_for_mfa_gmail()` captured `start_epoch_s = int(time.time())` at call time — 60–120s after Garmin already sent the MFA email (Chrome launch + page load + MFA detection all happen first). PR #87's strict `idate > start_ms` filter then correctly excluded the email, because it arrived before the anchor.

**Fix:** `_PULL_START_S = int(time.time())` as a module-level constant in `garmin.py`, captured at import time (= script start). Passed as `poll_start` to `wait_for_mfa_gmail()`. `timeout` bumped 300 → 600s for rate-limited Garmin delivery (observed 7-minute delivery on tester's VM after a week of failed login attempts).

## Bug 2 — Second `uc_open_with_reconnect` lands on omnibox popup frame

When `_do_login` called `uc_open_with_reconnect` on an already-open browser, ChromeDriver's active window handle pointed at Chrome's internal omnibox autocomplete popup (`chrome://omnibox-popup.top-chrome/`) instead of the page. `_probe_email_field` saw the `chrome://` URL, bailed as `"already past sign-in page"`, and handed off to `_wait_for_manual_login` — which times out in cron context.

**Fix:** after `uc_open_with_reconnect`, iterate `window_handles` and `switch_to.window` on the first handle whose URL doesn't start with `chrome://`. Also bumps `reconnect_time` 6 → 8 for KVM guests.

## Changes

| File | Change |
|---|---|
| `pullers/_gmail_mfa.py` | `poll_start` parameter; updated anchor + docstring |
| `pullers/garmin.py` | `_PULL_START_S` constant; updated call site (`timeout=600, poll_start=_PULL_START_S`); window handle iteration + `reconnect_time=8` in `_do_login` |

## Test plan

- [ ] Tester VM: wipe `.garmin_browser_profile/`, run `--days 1` — should re-login automatically, catch MFA via Gmail, complete pull
- [ ] Tester VM: run again immediately after (session active) — should skip login, pull cleanly
- [ ] Cron: tomorrow 6AM run on tester VM validates anchor timing under real conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)