### PR TITLE
fix(xvfb): remove stale /tmp/.X*-lock before starting Xvfb (#92)

### DIFF
--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -86,6 +86,10 @@ def start_xvfb(display=":99"):
             "which can install Xvfb for you.)"
         )
         sys.exit(1)
+    # Remove any stale lock file left by a prior crashed run. Xvfb exits
+    # immediately on startup if /tmp/.X<N>-lock exists, even when no process
+    # holds it — same pattern as the Singleton* cleanup for Chrome profiles.
+    Path(f"/tmp/.X{display.lstrip(':')}-lock").unlink(missing_ok=True)
     proc = subprocess.Popen(
         ["Xvfb", display, "-screen", "0", "1280x720x24"],
         stdout=subprocess.DEVNULL,


### PR DESCRIPTION
Fixes #92

## What

`start_xvfb()` now removes `/tmp/.X<N>-lock` before calling `Popen`. One line added before `Popen` in `pullers/garmin.py`.

## Why

Xvfb exits immediately on startup if the lock file from a prior crashed run is still present. The `Popen` call returns a handle to an already-dead process, `os.environ["DISPLAY"]` is set, and Chrome silently fails to find a display. Surfaced on the tester's KVM VM — 7 stale lock files required manual cleanup before a workaround run could proceed.

Same pattern as the `Singleton*` cleanup for Chrome profiles (PR #87): stale OS-level lock file from a crash blocks the next clean start.

## Test plan

- [ ] `kill -9` a running headless pull mid-Xvfb-startup, confirm `/tmp/.X99-lock` exists, run again — next run should start cleanly without manual lock removal
- [ ] Normal run unaffected: no lock file present, `unlink(missing_ok=True)` is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)