### PR TITLE
feat(logging): persistent date-stamped cron logs (#94)

### DIFF
--- a/scripts/pull-garmin.sh
+++ b/scripts/pull-garmin.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Daily Garmin Connect data pull
-# Runs via cron — logs to /tmp/garmin-pull.log
+# Logs to <project_dir>/logs/garmin-YYYY-MM-DD.log by default.
+# Override: GARMIN_PULL_LOG=/your/path pull-garmin.sh --push-both
 #
 # Cron example (6 AM daily):
 #   0 6 * * * /path/to/garmin-extract/scripts/pull-garmin.sh
@@ -17,7 +18,7 @@ set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PYTHON="${PROJECT_DIR}/.venv/bin/python"
-LOG="/tmp/garmin-pull.log"
+LOG="${GARMIN_PULL_LOG:-${PROJECT_DIR}/logs/garmin-$(date '+%Y-%m-%d').log}"
 
 PUSH_DRIVE=0
 PUSH_SHEETS=0
@@ -30,6 +31,7 @@ for arg in "$@"; do
     esac
 done
 
+mkdir -p "$(dirname "$LOG")"
 echo "=== $(date '+%Y-%m-%d %H:%M:%S') ===" >> "$LOG"
 cd "$PROJECT_DIR"
 "$PYTHON" pullers/garmin.py >> "$LOG" 2>&1


### PR DESCRIPTION
## Summary

- Moves default log path from `/tmp/garmin-pull.log` (wiped on reboot) to `<project_dir>/logs/garmin-YYYY-MM-DD.log`
- One file per calendar day — absent log file = VM was down or run never launched (no grep required)
- `GARMIN_PULL_LOG` env var overrides for users who prefer `/tmp` or a central log directory
- `logs/` is already gitignored; `mkdir -p` auto-creates it on first run

Closes #94

## Changes

`scripts/pull-garmin.sh` — 3 lines:
- `LOG` default updated to date-stamped path with env var override
- `mkdir -p "$(dirname "$LOG")"` added before first write
- Header comment updated

## Test plan

- [ ] Run `pull-garmin.sh` on Linux — confirm `logs/garmin-YYYY-MM-DD.log` is created and contains pull output
- [ ] Set `GARMIN_PULL_LOG=/tmp/test.log` and re-run — confirm override path is used
- [ ] Verify `logs/` directory is not tracked by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)