### PR TITLE
release: v1.6.3

### DIFF
--- a/pullers/_gmail_mfa.py
+++ b/pullers/_gmail_mfa.py
@@ -106,7 +106,7 @@ def _get_message_text(service, msg_id: str) -> str:
     return plain or html
 
 
-def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
+def wait_for_mfa_gmail(timeout: int = 300, poll_start: float | None = None) -> str | None:
     """
     Poll Gmail for a Garmin MFA code. Returns the code string, or None
     if credentials are unavailable or the poll times out.
@@ -116,6 +116,9 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
 
     Args:
         timeout: seconds to poll before giving up (default 5 minutes)
+        poll_start: epoch seconds to use as the internalDate anchor instead of
+            now. Pass the script's import-time timestamp so emails sent during
+            browser startup (before this function is called) are not excluded.
     """
     service = _build_gmail_service()
     if not service:
@@ -123,11 +126,12 @@ def wait_for_mfa_gmail(timeout: int = 300) -> str | None:
 
     print("  [gmail] Polling inbox for Garmin MFA code...")
 
-    # Only look at emails received after this script started. Gmail's after: filter
-    # is second-precision, so a matching email that arrived within the same second as
-    # start_epoch_s can slip through; we apply a strict ms-level internalDate filter
-    # below as the authoritative guard against stale codes from prior runs.
-    start_epoch_s = int(time.time())
+    # Anchor to poll_start (script import time) rather than now. Garmin sends
+    # the MFA email during the login sequence — 60–120s before this function is
+    # called on a typical headless VM. Using time.time() here sets start_ms in
+    # the future relative to the email's internalDate, causing the strict filter
+    # below to exclude the very email we're looking for.
+    start_epoch_s = int(poll_start) if poll_start is not None else int(time.time())
     start_ms = start_epoch_s * 1000
     poll_interval = 5  # seconds between checks
     elapsed = 0

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -86,6 +86,10 @@ def start_xvfb(display=":99"):
             "which can install Xvfb for you.)"
         )
         sys.exit(1)
+    # Remove any stale lock file left by a prior crashed run. Xvfb exits
+    # immediately on startup if /tmp/.X<N>-lock exists, even when no process
+    # holds it — same pattern as the Singleton* cleanup for Chrome profiles.
+    Path(f"/tmp/.X{display.lstrip(':')}-lock").unlink(missing_ok=True)
     proc = subprocess.Popen(
         ["Xvfb", display, "-screen", "0", "1280x720x24"],
         stdout=subprocess.DEVNULL,

--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -46,6 +46,11 @@ DATA_DIR = ROOT / "data" / "garmin"
 PROFILE_DIR = ROOT / ".garmin_browser_profile"
 MFA_FILE = ROOT / ".mfa_code"
 RATE_LIMIT = 0.5  # seconds between API calls
+# Captured at import time (= script start). Passed to wait_for_mfa_gmail() so
+# the internalDate filter anchors to before browser startup, not after — Garmin
+# sends the MFA email during the login sequence, which completes 60–120s before
+# wait_for_mfa_gmail() is ever called.
+_PULL_START_S = int(time.time())
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +142,7 @@ def wait_for_mfa() -> str:
 
         if is_configured():
             print("MFA REQUIRED — polling Gmail automatically...")
-            code = wait_for_mfa_gmail(timeout=300)
+            code = wait_for_mfa_gmail(timeout=600, poll_start=_PULL_START_S)
             if code:
                 print("MFA obtained.")
                 return code
@@ -254,8 +259,18 @@ def _do_login(sb, email: str, password: str) -> None:
     sb.uc_open_with_reconnect(
         "https://sso.garmin.com/portal/sso/en-US/sign-in"
         "?clientId=GarminConnect&consumeServiceTicket=false",
-        reconnect_time=6,
+        reconnect_time=8,
     )
+    # UC reconnect on an already-open browser can leave ChromeDriver focused on
+    # a Chrome-internal frame (omnibox autocomplete popup). Iterate handles to
+    # land on the first real page context before probing the email field.
+    try:
+        for handle in sb.driver.window_handles:
+            sb.driver.switch_to.window(handle)
+            if not sb.get_current_url().startswith("chrome://"):
+                break
+    except Exception:
+        pass
     sb.sleep(5)
 
     ready, reason = _probe_email_field(sb)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "garmin-extract"
-version = "1.6.2"
+version = "1.6.3"
 description = "Automated Garmin Connect data pipeline using browser automation"
 requires-python = ">=3.12"
 dependencies = [

--- a/scripts/pull-garmin.sh
+++ b/scripts/pull-garmin.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Daily Garmin Connect data pull
-# Runs via cron — logs to /tmp/garmin-pull.log
+# Logs to <project_dir>/logs/garmin-YYYY-MM-DD.log by default.
+# Override: GARMIN_PULL_LOG=/your/path pull-garmin.sh --push-both
 #
 # Cron example (6 AM daily):
 #   0 6 * * * /path/to/garmin-extract/scripts/pull-garmin.sh
@@ -17,7 +18,7 @@ set -euo pipefail
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PYTHON="${PROJECT_DIR}/.venv/bin/python"
-LOG="/tmp/garmin-pull.log"
+LOG="${GARMIN_PULL_LOG:-${PROJECT_DIR}/logs/garmin-$(date '+%Y-%m-%d').log}"
 
 PUSH_DRIVE=0
 PUSH_SHEETS=0
@@ -30,6 +31,7 @@ for arg in "$@"; do
     esac
 done
 
+mkdir -p "$(dirname "$LOG")"
 echo "=== $(date '+%Y-%m-%d %H:%M:%S') ===" >> "$LOG"
 cd "$PROJECT_DIR"
 "$PYTHON" pullers/garmin.py >> "$LOG" 2>&1


### PR DESCRIPTION
## v1.6.3

Three bug fixes / improvements targeting headless Linux reliability, all confirmed working by end-to-end testing.

### Changes

**fix: MFA anchor regression + UC reconnect omnibox frame (#90 / PR #91)**
- `_gmail_mfa.py`: add `poll_start` parameter; `start_epoch_s` now anchors to script start (`_PULL_START_S` module constant in `garmin.py`) instead of when `wait_for_mfa_gmail()` is called — prevents the 60–120s browser startup window from excluding the MFA email
- `garmin.py`: `wait_for_mfa_gmail(timeout=600)` — bumped from 300s to give margin for slow Garmin delivery
- `garmin.py` `_do_login`: iterate `window_handles` for first non-`chrome://` URL after `uc_open_with_reconnect` — fixes ChromeDriver landing on the omnibox popup frame instead of the page; `reconnect_time` bumped 6 → 8

**fix: remove stale `/tmp/.X*-lock` before starting Xvfb (#92 / PR #93)**
- Clears stale X lock files left by crashed runs before launching Xvfb — prevents "failed to close window in 20 seconds" on the next run

**feat: persistent date-stamped cron logs (#94 / PR #95)**
- `scripts/pull-garmin.sh`: log path moves from `/tmp/garmin-pull.log` (wiped on reboot) to `<project_dir>/logs/garmin-YYYY-MM-DD.log`
- One file per day — absent file = VM was down or run never launched
- `GARMIN_PULL_LOG` env var overrides for custom paths
- `logs/` already gitignored; directory auto-created on first run

## Upgrade notes

No breaking changes. No migration needed. Users with custom cron entries pointing at `/tmp/garmin-pull.log` should note the new default log location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)