### PR TITLE
fix(garmin): wait for orphaned pids to fully exit before Chrome launch

### DIFF
--- a/pullers/garmin.py
+++ b/pullers/garmin.py
@@ -106,6 +106,11 @@ def _reap_profile_orphans(profile_dir: Path) -> None:
     Narrow match on the profile path — we only SIGKILL processes whose argv
     references this specific user-data-dir, so unrelated Chrome sessions
     (e.g. a dev's desktop browser) are untouched.
+
+    Waits for all killed pids to fully exit before returning. SIGKILL is
+    asynchronous — the kernel schedules termination but file handles and profile
+    locks are not released until exit completes. Returning early races Chrome's
+    profile acquisition against the dying processes.
     """
     if shutil.which("pgrep") is None:
         return
@@ -120,6 +125,8 @@ def _reap_profile_orphans(profile_dir: Path) -> None:
         return
     if r.returncode != 0:
         return
+
+    killed = []
     for pid_str in r.stdout.split():
         try:
             pid = int(pid_str)
@@ -130,8 +137,34 @@ def _reap_profile_orphans(profile_dir: Path) -> None:
         try:
             os.kill(pid, signal.SIGKILL)
             print(f"  [cleanup] killed orphaned pid {pid} holding profile")
+            killed.append(pid)
         except (ProcessLookupError, PermissionError):
             pass
+
+    if not killed:
+        return
+
+    # Poll until every killed pid is confirmed gone. os.kill(pid, 0) raises
+    # ProcessLookupError (ESRCH) once the kernel removes the process table entry,
+    # which is the authoritative signal that file handles and profile locks are
+    # released.
+    deadline = time.monotonic() + 3.0
+    remaining = set(killed)
+    while remaining and time.monotonic() < deadline:
+        still_alive = set()
+        for pid in remaining:
+            try:
+                os.kill(pid, 0)
+                still_alive.add(pid)
+            except ProcessLookupError:
+                pass  # confirmed gone
+            except PermissionError:
+                still_alive.add(pid)  # still exists, can't signal
+        remaining = still_alive
+        if remaining:
+            time.sleep(0.05)
+    if remaining:
+        print(f"  [cleanup] warning: {len(remaining)} orphan(s) did not exit within 3s; proceeding")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_reap_profile_orphans` previously sent `SIGKILL` to orphaned Chrome/uc_driver processes and returned immediately
- `SIGKILL` is asynchronous — the kernel schedules termination but profile locks are not released until exit completes
- This created a race: the new Chrome instance would try to acquire the profile before the dying process fully released it, producing `"failed to close window in 20 seconds"` on rapid-retry runs
- Fix: after sending `SIGKILL`, poll `os.kill(pid, 0)` in a 50ms loop (3s max timeout) until each pid raises `ProcessLookupError` — kernel's authoritative confirmation that the process table entry (and its locks) are gone — before returning

## Test plan

- [ ] Invoke puller, `kill -9` mid-launch, then invoke again immediately — subsequent run should print `[cleanup] killed orphaned pid ...` lines and proceed without "failed to close window" error
- [ ] Clean run with no orphans — no behavior change, no warning lines
- [ ] Cron run on headless KVM VM — daily 6AM validation

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)